### PR TITLE
Migrate router to address-based V1 interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,25 @@ Single-hop router that quotes and executes swaps against a proprietary AMM (Ferm
 
 ## Overview
 
-The router exposes a `Venue` enum (`Fallback`, `FermiSwap`, `Kipseli`, `Bebop`) and the following external functions (see `src/interfaces/IPropAMMRouter.sol` for the full NatSpec):
+Venues are identified **by address**: the three proprietary AMM routers (FermiSwap, Kipseli, Bebop) plus the Uniswap V3 fallback, denoted by the SwapRouter02 address wired in at deployment. The router exposes the following external functions (see `src/interfaces/IPropAMMRouter.sol` for the full NatSpec):
 
-- `swap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, uniswapFee, deadline)`: pulls `amountIn` of `tokenIn` from `msg.sender`, attempts the swap on the selected venue, and falls back to Uniswap V3 (using `uniswapFee` as the pool tier) if that venue reverts or under-delivers. Passing `Venue.Fallback` skips the proprietary AMMs and routes directly to Uniswap V3. Enforces `amountOutMin` on the measured balance delta of `recipient`. Reverts when the contract is paused (see [Pausing the contract](#pausing-the-contract)); quote functions remain callable.
-- `quote(tokenIn, tokenOut, amount, uniswapFee)`: quotes every venue (the proprietary AMMs and the Uniswap V3 fallback at `uniswapFee`) and returns the best `amountOut` along with the venue that produced it. Reverts `NoQuotesAvailable` if every venue is skipped or reverts. A 3-arg overload `quote(tokenIn, tokenOut, amount)` uses `DEFAULT_FALLBACK_FEE` (`3000`, i.e. the 0.30% tier) for the Uniswap V3 branch.
-- `quoteVenue(venue, tokenIn, tokenOut, amount, uniswapFee)`: quotes a single specified venue. Reverts `UnknownVenue` for unsupported enum values and bubbles up any underlying venue revert. A 4-arg overload `quoteVenue(venue, tokenIn, tokenOut, amount)` uses `DEFAULT_FALLBACK_FEE` when `venue` is `Venue.Fallback` (and is ignored otherwise).
+- `swapV1(tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: pulls `amountIn` of `tokenIn` from `msg.sender`, routes through the best-quoting venue, and falls back to Uniswap V3 if that venue reverts or under-delivers. Returns `(amountOut, executedVenue)`, where `executedVenue` is the proprietary venue that filled or the SwapRouter02 address when the fallback ran. Reverts `QuoteBelowMinimum` before pulling funds if the best quote is below `amountOutMin`, and re-checks `amountOutMin` against the measured balance delta of `recipient` after execution. Reverts when the contract is paused (see [Pausing the contract](#pausing-the-contract)); quote functions remain callable.
+- `swapViaVenueV1(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: attempts the caller-specified `venue` first. A proprietary venue still falls back to Uniswap V3 if it fails to fill; naming the Uniswap V3 SwapRouter02 address routes directly to Uniswap V3 (it *is* the fallback, so there is nothing further to fall back to). Reverts `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the SwapRouter02 address.
+- `quoteV1(tokenIn, tokenOut, amount)`: quotes every venue (the proprietary AMMs and the Uniswap V3 fallback) and returns the best `amountOut` along with the venue address that produced it. Reverts `NoQuotesAvailable` if every venue is skipped or reverts.
+- `quoteVenueV1(venue, tokenIn, tokenOut, amount)`: quotes a single venue by address. Reverts `UnknownVenue` for any address that is neither a proprietary AMM nor the SwapRouter02 fallback, and bubbles up any underlying venue revert.
 
-For pairs whose deepest Uniswap V3 pool is not at the 0.30% tier (e.g. USDC/WETH on mainnet, which is `500`), prefer the explicit-fee overloads.
+The Uniswap V3 fallback always prices and swaps at the owner-settable `fallbackFee` pool tier (`3000`, i.e. the 0.30% tier, by default) — callers never pass a fee. For pairs whose deepest Uniswap V3 pool is not at the 0.30% tier (e.g. USDC/WETH on mainnet, which is `500`), the owner retunes it with `setFallbackFee` (no contract upgrade required).
 
 ### Kipseli quote caveat
 
 Kipseli does not expose a usable on-chain quote function. To price it, the router calls `Kipseli.simulateKipseliSwap`, which executes a real swap and then reverts with the resulting `amountOut` ABI-encoded in the revert payload. The router decodes that payload to recover the quote.
 
-The Uniswap V3 `Venue.Fallback` branch also prices via revert-based simulation, since QuoterV2 reverts with the simulated `amountOut`.
+The Uniswap V3 fallback branch also prices via revert-based simulation, since QuoterV2 reverts with the simulated `amountOut`.
 
 As a consequence:
 
-- `quote` and `quoteVenue` are not `view`. They must be called via `eth_call` (staticcall) from off-chain so the simulated swaps are rolled back automatically.
-- The Kipseli simulation pulls `tokenIn` from the router's own balance. When quoting against Kipseli (directly via `quoteVenue`, or implicitly through `quote`), the RPC call must include a `stateDiff` override that gives the router a sufficient balance of `tokenIn`. Without the override, the Kipseli branch is silently skipped while the other branches still quote.
+- `quoteV1` and `quoteVenueV1` are not `view`. They must be called via `eth_call` (staticcall) from off-chain so the simulated swaps are rolled back automatically.
+- The Kipseli simulation pulls `tokenIn` from the router's own balance. When quoting against Kipseli (directly via `quoteVenueV1`, or implicitly through `quoteV1`), the RPC call must include a `stateDiff` override that gives the router a sufficient balance of `tokenIn`. Without the override, the Kipseli branch is silently skipped while the other branches still quote.
 
 ## Prerequisites
 
@@ -51,7 +52,7 @@ forge clean && forge script scripts/Deploy.s.sol \
 
 ### Quoting with Titan state overrides
 
-The proprietary AMMs maintain off-chain liquidity that is not reflected by mainnet state, so a plain `eth_call` to `PropAMMRouter.quote` against the anvil fork only sees stale liquidity. To get accurate quotes, Titan exposes the JSON-RPC method `titan_getPammStateOverrides`, whose result is passed as the third parameter of `eth_call`.
+The proprietary AMMs maintain off-chain liquidity that is not reflected by mainnet state, so a plain `eth_call` to `PropAMMRouter.quoteV1` against the anvil fork only sees stale liquidity. To get accurate quotes, Titan exposes the JSON-RPC method `titan_getPammStateOverrides`, whose result is passed as the third parameter of `eth_call`.
 The Titan endpoint only serves `titan_getPammStateOverrides`. The `eth_call` itself is sent to the anvil fork.
 
 The response is keyed by proprietary AMM router address, with one entry per venue:
@@ -67,7 +68,7 @@ The response is keyed by proprietary AMM router address, with one entry per venu
 }
 ```
 
-The three keys are the FermiSwap, Bebop, and Kipseli routers, respectively. When calling `quoteVenue(venue, ...)`, pick the entry matching the venue you want to quote. Kipseli additionally requires the router to hold `tokenIn`, since `simulateKipseliSwap` transfers it to Kipseli; we fund it with a `stateDiff` over the token contract's `_balances` slot for the router. FermiSwap and Bebop ignore the balance override, so the same snippet works for all three proprietary venues (only the address and the enum value need to change). For `Venue.Fallback` the Titan overrides aren't needed at all — Uniswap V3's QuoterV2 only reads on-chain pool state — so you can skip the `titan_getPammStateOverrides` call entirely and pass an empty state override (or omit the third `eth_call` parameter).
+The three keys are the FermiSwap, Bebop, and Kipseli routers, respectively. When calling `quoteVenueV1(venue, ...)`, pick the entry matching the venue address you want to quote. Kipseli additionally requires the router to hold `tokenIn`, since `simulateKipseliSwap` transfers it to Kipseli; we fund it with a `stateDiff` over the token contract's `_balances` slot for the router. FermiSwap and Bebop ignore the balance override, so the same snippet works for all three proprietary venues (only the venue address needs to change). For the Uniswap V3 fallback (naming the SwapRouter02 address) the Titan overrides aren't needed at all — QuoterV2 only reads on-chain pool state — so you can skip the `titan_getPammStateOverrides` call entirely and pass an empty state override (or omit the third `eth_call` parameter).
 
 **Example: quote 1 WETH for USDC against the deployed router on the anvil fork.**
 
@@ -77,17 +78,17 @@ ROUTER=<PropAMMRouter proxy address logged by Deploy.s.sol>
 WETH=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
 USDC=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
 
-# === Pick the venue to quote (only edit these two lines) ===
-# Venue enum: 0 = Fallback (Uniswap V3), 1 = FermiSwap, 2 = Kipseli, 3 = Bebop.
+# === Pick the venue to quote (only edit this line) ===
+# Venues are addresses: the Uniswap V3 fallback is the SwapRouter02 address;
+# the three proprietary AMM routers are listed in the table below.
 VENUE_ADDR=0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c    # Kipseli
-VENUE_ENUM=2
 
 # WETH stores balances in storage slot 3 (mapping(address => uint)).
 # balanceOf[ROUTER] lives at keccak256(abi.encode(ROUTER, 3)).
 WETH_BAL_SLOT=$(cast index address $ROUTER 3)
 
 # 1. Fetch the venue's Titan overrides and fund the router with 10 WETH.
-#    (Skip this step for Venue.Fallback — QuoterV2 only needs on-chain state.)
+#    (Skip this step for the Uniswap V3 fallback — QuoterV2 only needs on-chain state.)
 OVERRIDES=$(curl -s -X POST https://eu.rpc.titanbuilder.xyz \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","id":1,"method":"titan_getPammStateOverrides","params":[]}' \
@@ -96,11 +97,10 @@ OVERRIDES=$(curl -s -X POST https://eu.rpc.titanbuilder.xyz \
         + { ($weth): { stateDiff: { ($slot): "0x0000000000000000000000000000000000000000000000008ac7230489e80000" } } }
       ')
 
-# 2. eth_call PropAMMRouter.quoteVenue(venue, WETH, USDC, 1e18) with the overrides.
-#    This uses the no-fee overload, which falls back to DEFAULT_FALLBACK_FEE (3000)
-#    when VENUE_ENUM is 0; for a different Uniswap V3 tier, use the 5-arg overload
-#    `quoteVenue(uint8,address,address,uint256,uint24)`.
-DATA=$(cast calldata "quoteVenue(uint8,address,address,uint256)" $VENUE_ENUM $WETH $USDC 1000000000000000000)
+# 2. eth_call PropAMMRouter.quoteVenueV1(venue, WETH, USDC, 1e18) with the overrides.
+#    The Uniswap V3 fallback always prices at the owner-set `fallbackFee` tier
+#    (3000 by default); there is no per-call fee argument.
+DATA=$(cast calldata "quoteVenueV1(address,address,address,uint256)" $VENUE_ADDR $WETH $USDC 1000000000000000000)
 
 curl -s -X POST $RPC_URL -H "Content-Type: application/json" \
     -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_call\",\"params\":[{\"to\":\"$ROUTER\",\"data\":\"$DATA\"},\"latest\",$OVERRIDES]}" \
@@ -108,14 +108,14 @@ curl -s -X POST $RPC_URL -H "Content-Type: application/json" \
     | xargs cast --abi-decode "f()(uint256)"
 ```
 
-This prints `amountOut`, e.g. `2115659878` (≈ 2115.66 USDC for 1 WETH, with USDC's 6 decimals) at the current state. To quote a different venue, edit only `VENUE_ADDR` and `VENUE_ENUM`:
+This prints `amountOut`, e.g. `2115659878` (≈ 2115.66 USDC for 1 WETH, with USDC's 6 decimals) at the current state. To quote a different venue, edit only `VENUE_ADDR`:
 
-| Venue | `VENUE_ADDR` | `VENUE_ENUM` |
-|-------|--------------|--------------|
-| Fallback (Uniswap V3) | n/a — skip the Titan call | `0` |
-| FermiSwap | `0xb1076fe3ab5e28005c7c323bac5ac06a680d452e` | `1` |
-| Kipseli | `0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c` | `2` |
-| Bebop | `0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea` | `3` |
+| Venue | `VENUE_ADDR` |
+|-------|--------------|
+| Uniswap V3 fallback (SwapRouter02) | `0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45` — skip the Titan call |
+| FermiSwap | `0xb1076fe3ab5e28005c7c323bac5ac06a680d452e` |
+| Kipseli | `0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c` |
+| Bebop | `0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea` |
 
 ### Pausing the contract
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Venues are identified **by address**: the three proprietary AMM routers (FermiSw
 
 - `swapV1(tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: pulls `amountIn` of `tokenIn` from `msg.sender`, routes through the best-quoting venue, and falls back to Uniswap V3 if that venue reverts or under-delivers. Returns `(amountOut, executedVenue)`, where `executedVenue` is the proprietary venue that filled or the SwapRouter02 address when the fallback ran. Reverts `QuoteBelowMinimum` before pulling funds if the best quote is below `amountOutMin`, and re-checks `amountOutMin` against the measured balance delta of `recipient` after execution. Reverts when the contract is paused (see [Pausing the contract](#pausing-the-contract)); quote functions remain callable.
 - `swapViaVenueV1(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: attempts the caller-specified `venue` first. A proprietary venue still falls back to Uniswap V3 if it fails to fill; naming the Uniswap V3 SwapRouter02 address routes directly to Uniswap V3 (it *is* the fallback, so there is nothing further to fall back to). Reverts `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the SwapRouter02 address.
+- `swapViaSelectedVenuesV1(venues, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: like `swapV1`, but considers only the caller-supplied `venues` subset. An on-chain requote across them selects the best, which executes — with the Uniswap V3 fallback still applying as the transparent safety net if the chosen venue fails to fill. Reverts `NoQuotesAvailable` if none of the listed venues can be priced. Returns `(amountOut, executedVenue)`. List the SwapRouter02 address among `venues` to opt Uniswap V3 into the selection (it is not a selection candidate otherwise, only the execution-time safety net).
 - `quoteV1(tokenIn, tokenOut, amount)`: quotes every venue (the proprietary AMMs and the Uniswap V3 fallback) and returns the best `amountOut` along with the venue address that produced it. Reverts `NoQuotesAvailable` if every venue is skipped or reverts.
 - `quoteVenueV1(venue, tokenIn, tokenOut, amount)`: quotes a single venue by address. Reverts `UnknownVenue` for any address that is neither a proprietary AMM nor the SwapRouter02 fallback, and bubbles up any underlying venue revert.
+- `quoteSelectedVenuesV1(venues, tokenIn, tokenOut, amountIn)`: quotes only the caller-supplied `venues` subset and returns the best `(bestAmountOut, bestVenue)`. Venues that revert (including non-whitelisted addresses) are skipped; reverts `NoQuotesAvailable` if none of them can be priced.
 
 The Uniswap V3 fallback always prices and swaps at the owner-settable `fallbackFee` pool tier (`3000`, i.e. the 0.30% tier, by default) — callers never pass a fee. For pairs whose deepest Uniswap V3 pool is not at the 0.30% tier (e.g. USDC/WETH on mainnet, which is `500`), the owner retunes it with `setFallbackFee` (no contract upgrade required).
 
@@ -121,8 +123,8 @@ This prints `amountOut`, e.g. `2115659878` (≈ 2115.66 USDC for 1 WETH, with US
 
 The router is `PausableUpgradeable`. The owner can stop all new swaps with:
 
-- `pause()` — owner-gated; flips the contract into the paused state. While paused, `swap` reverts with OpenZeppelin's `EnforcedPause` error. `quote` and `quoteVenue` are unaffected and remain callable.
-- `unpause()` — owner-gated; clears the paused state and re-enables `swap`.
+- `pause()` — owner-gated; flips the contract into the paused state. While paused, `swapV1`, `swapViaVenueV1`, and `swapViaSelectedVenuesV1` revert with OpenZeppelin's `EnforcedPause` error. `quoteV1`, `quoteVenueV1`, and `quoteSelectedVenuesV1` are unaffected and remain callable.
+- `unpause()` — owner-gated; clears the paused state and re-enables swaps.
 
 Both functions are restricted to the proxy owner (the address passed as `ROUTER_OWNER` at deployment, or the current owner after an `Ownable2Step` handoff). The state initializes to unpaused on `initialize`.
 

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -18,12 +18,17 @@ import {UniV3Router} from "./libraries/UniV3Router.sol";
 
 /// @title PropAMMRouter
 /// @notice Routes single-hop swaps to a proprietary AMM (FermiSwap, Kipseli, or
-/// Bebop) or directly to Uniswap V3, and falls back to Uniswap V3 if the
-/// chosen proprietary venue reverts.
+/// Bebop) and falls back to Uniswap V3 if the chosen proprietary venue reverts.
 /// @dev Designed to live behind a UUPS proxy. The fallback path is wired at
 /// initialization via `fallbackSwapRouter` (SwapRouter02) and `fallbackQuoter`
-/// (QuoterV2); proprietary venue addresses are hardcoded as constants. The
-/// owner authorized in `initialize` controls upgrades via `_authorizeUpgrade`.
+/// (QuoterV2); proprietary venue addresses are hardcoded as constants. Venues
+/// are identified by address: the whitelist of venues a caller may name
+/// explicitly is exactly the three proprietary AMMs (see `_isVenue`). Uniswap V3
+/// is never named directly — it is folded into `quoteV1` as a baseline price and
+/// is reached automatically (best-quote selection in `swapV1`, or as the failure
+/// fallback). The Uniswap fee tier is the owner-settable `fallbackFee`, so
+/// callers never pass one. The owner authorized in `initialize` controls
+/// upgrades via `_authorizeUpgrade`.
 contract PropAMMRouter is
     IPropAMMRouter,
     ReentrancyGuardTransient,
@@ -39,30 +44,29 @@ contract PropAMMRouter is
     address fallbackSwapRouter;
     /// @notice Uniswap V3 QuoterV2 used to price the fallback route off-chain.
     address fallbackQuoter;
+    /// @notice Uniswap V3 pool fee tier (in hundredths of a bip) used for the
+    /// Uniswap fallback quote and swap. `3000` = 0.30% by default; the owner can
+    /// retune it via `setFallbackFee` without a contract upgrade. Appended after
+    /// the existing storage variables to keep the UUPS layout upgrade-safe.
+    uint24 public fallbackFee;
 
-    /// @notice Default Uniswap V3 pool fee tier (in hundredths of a bip) used
-    /// by the no-fee `quote` and `quoteVenue` overloads when pricing the
-    /// `Venue.Fallback` branch. `3000` = 0.30%, a common "blue-chip" tier
-    /// but not always the deepest pool for a given pair — callers wanting a
-    /// different pool should use the explicit-fee overloads.
-    uint24 public constant DEFAULT_FALLBACK_FEE = 3000;
-
-    /// @notice Thrown when `swapViaVenue` is called by anyone other than this
-    /// contract itself, i.e. outside of the `try`-wrapped self-call made by `swap`.
+    /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
+    /// contract itself, i.e. outside of the `try`-wrapped self-call made by
+    /// `_coreSwap`.
     error OnlySelf();
-    /// @notice Thrown when `venue` does not match any supported `Venue` value.
+    /// @notice Thrown when `venue` is not one of the whitelisted proprietary AMMs.
     error UnknownVenue();
-    /// @notice Thrown when `swap` cannot deliver at least `amountOutMin` of
+    /// @notice Thrown when a swap cannot deliver at least `amountOutMin` of
     /// `tokenOut` to `recipient`.
     /// @param expectedAmount The minimum acceptable amount of `tokenOut` (i.e.
     /// the caller's `amountOutMin`).
     /// @param receivedAmount The actual amount of `tokenOut` delivered to
     /// `recipient`, measured as a balance delta against the pre-swap snapshot.
     error InsufficientOutput(uint256 expectedAmount, uint256 receivedAmount);
-    /// @notice Thrown when `swap` is invoked after its `deadline`.
+    /// @notice Thrown when a swap is invoked after its `deadline`.
     error Expired();
-    /// @notice Thrown when no proprietary venue can produce a quote for the
-    /// requested pair and amount.
+    /// @notice Thrown when no venue can produce a quote for the requested pair
+    /// and amount.
     error NoQuotesAvailable();
     /// @notice Thrown when `tokenOut` balance decreases after a swap.
     error TokenOutBalanceDecreased();
@@ -90,99 +94,151 @@ contract PropAMMRouter is
     ) public initializer {
         fallbackSwapRouter = fallbackSwapRouter_;
         fallbackQuoter = fallbackQuoter_;
+        fallbackFee = 3000;
         __Ownable_init(owner_);
         __Ownable2Step_init();
         __Pausable_init();
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Pulls `amountIn` of `tokenIn` from `msg.sender` once, then attempts
-    /// the chosen venue's swap via an external `this.swapViaVenue` call so a
-    /// failure can be caught and recovered with a Uniswap V3 fallback. The
-    /// external self-call is intentional: it isolates the venue call's revert
-    /// from this function's frame so `try/catch` can engage. The catch arm
-    /// doubles as the Uniswap V3 execution path: when `venue` is
-    /// `Venue.Fallback`, `swapViaVenue` reverts immediately with no work
-    /// done so the catch arm engages and runs Uniswap V3 — a single code
-    /// path serves both "proprietary venue failed" and "caller explicitly
-    /// asked for Fallback", at the cost of one wasted self-call frame in
-    /// the latter case. The slippage guarantee is enforced inside each
-    /// branch: `swapViaVenue` checks the measured delta internally before
-    /// returning (a failure there reverts and is caught here, triggering
-    /// the fallback), and the catch arm re-measures after Uniswap to defend
-    /// against an under-delivering fallback router.
-    function swap(
-        Venue venue,
+    /// @dev Picks the best-quoting venue across the proprietary AMMs and the
+    /// Uniswap V3 baseline via `_pickBestVenue`, then executes it through
+    /// `_coreSwap`. If every venue fails to quote, `_pickBestVenue` yields
+    /// `address(0)` and `_coreSwap` routes straight to the Uniswap fallback.
+    function swapV1(
         address tokenIn,
         address tokenOut,
         uint256 amountIn,
         uint256 amountOutMin,
         address recipient,
-        uint24 uniswapFee,
         uint256 deadline
-    ) public whenNotPaused nonReentrant returns (uint256) {
-        require(block.timestamp <= deadline, Expired());
-        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
-
-        uint256 prevTokenOutBalance = IERC20(tokenOut).balanceOf(recipient);
-
-        uint256 amountOut;
-        try
-            this.swapViaVenue(
+    )
+        external
+        whenNotPaused
+        nonReentrant
+        returns (uint256 amountOut, address executedVenue)
+    {
+        (, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
+        return
+            _coreSwap(
                 venue,
                 tokenIn,
                 tokenOut,
                 amountIn,
                 amountOutMin,
                 recipient,
-                deadline,
-                prevTokenOutBalance
-            )
-        returns (uint256 amountOut_) {
-            amountOut = amountOut_;
-        } catch {
-            swapViaUniswapV3(
-                tokenIn,
-                tokenOut,
-                amountIn,
-                amountOutMin,
-                uniswapFee,
-                recipient
+                deadline
             );
-            amountOut =
-                IERC20(tokenOut).balanceOf(recipient) -
-                prevTokenOutBalance;
-            require(
-                amountOut >= amountOutMin,
-                InsufficientOutput(amountOutMin, amountOut)
-            );
-        }
-        return amountOut;
     }
 
-    /// @notice Executes a swap on the selected venue with funds already held
-    /// by this contract.
-    /// @dev External (not internal) because `swap` invokes it as
-    /// `this.swapViaVenue(...)` to wrap the venue call in a try/catch — only
-    /// external calls produce a catchable frame, and a revert there also
-    /// rolls back the per-venue `forceApprove` issued below. The router must
-    /// already hold `amountIn` of `tokenIn`; this function approves the
-    /// selected venue for `amountIn` and the venue pulls during its own swap.
-    /// Gated on `msg.sender == address(this)` so only the self-call from
-    /// `swap` can enter (reverts `OnlySelf` otherwise). For `Venue.Fallback`
-    /// this function reverts immediately with no work done so that `swap`'s
-    /// existing catch arm runs the Uniswap V3 swap — this deliberately
-    /// reuses the catch arm as the single Uniswap V3 execution path (one
-    /// place that handles approval reset, balance delta, and slippage
-    /// recheck), at the cost of one wasted self-call frame versus branching
-    /// in `swap` directly. After the proprietary venue call, measures the
-    /// delivered delta on `recipient` and reverts if it is below
-    /// `amountOutMin` — by reverting (rather than returning a thin amount)
-    /// the under-fill is caught by the outer try/catch in `swap` and
-    /// triggers the Uniswap V3 fallback. Also reverts `UnknownVenue` for
-    /// unrecognized enum values, or bubbles up the underlying proprietary
-    /// router's revert.
-    /// @param venue The venue to route the swap through.
+    /// @inheritdoc IPropAMMRouter
+    /// @dev `venue` must be a whitelisted proprietary AMM (`_isVenue`); Uniswap
+    /// V3 cannot be named here and is only reached as the failure fallback
+    /// inside `_coreSwap`.
+    function swapViaVenueV1(
+        address venue,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline
+    ) public whenNotPaused nonReentrant returns (uint256 amountOut) {
+        require(_isVenue(venue), UnknownVenue());
+        (amountOut, ) = _coreSwap(
+            venue,
+            tokenIn,
+            tokenOut,
+            amountIn,
+            amountOutMin,
+            recipient,
+            deadline
+        );
+    }
+
+    /// @notice Pulls funds once and executes a swap, attempting `venue` first
+    /// and recovering on Uniswap V3 if it fails.
+    /// @dev Shared core for `swapV1` and `swapViaVenueV1`; unguarded so the two
+    /// public entrypoints can each apply `whenNotPaused`/`nonReentrant` without
+    /// re-entering the guard through one another. Pulls `amountIn` of `tokenIn`
+    /// from `msg.sender`, snapshots `recipient`'s `tokenOut` balance, then:
+    /// for a proprietary `venue`, wraps the venue call in `try this._dispatchVenue`
+    /// so a revert (including an under-fill, which `_dispatchVenue` turns into a
+    /// revert) is caught and recovered on Uniswap V3; for `fallbackSwapRouter`
+    /// or `address(0)` it runs Uniswap V3 directly, avoiding a pointless
+    /// Uniswap-to-Uniswap fallback. The external self-call is intentional: only
+    /// an external call produces a catchable frame and rolls back the venue's
+    /// `forceApprove`. The Uniswap branch re-measures the delivered delta and
+    /// enforces `amountOutMin` to defend against an under-delivering router.
+    /// @param venue The venue to attempt first: a proprietary AMM, or
+    /// `fallbackSwapRouter`/`address(0)` to go straight to Uniswap V3.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
+    /// @param recipient The address that will receive `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @return amountOut The amount of `tokenOut` delivered to `recipient`.
+    /// @return executedVenue The venue that filled the swap; `fallbackSwapRouter`
+    /// when Uniswap V3 ran.
+    function _coreSwap(
+        address venue,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline
+    ) internal returns (uint256 amountOut, address executedVenue) {
+        require(block.timestamp <= deadline, Expired());
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+
+        uint256 prevTokenOutBalance = IERC20(tokenOut).balanceOf(recipient);
+
+        if (venue != address(0) && venue != fallbackSwapRouter) {
+            try
+                this._dispatchVenue(
+                    venue,
+                    tokenIn,
+                    tokenOut,
+                    amountIn,
+                    amountOutMin,
+                    recipient,
+                    deadline,
+                    prevTokenOutBalance
+                )
+            returns (uint256 amountOut_) {
+                return (amountOut_, venue);
+            } catch {
+                // Fall through to the Uniswap V3 fallback below.
+            }
+        }
+
+        swapViaUniswapV3(tokenIn, tokenOut, amountIn, amountOutMin, recipient);
+        amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
+        require(
+            amountOut >= amountOutMin,
+            InsufficientOutput(amountOutMin, amountOut)
+        );
+        return (amountOut, fallbackSwapRouter);
+    }
+
+    /// @notice Executes a swap on a proprietary venue with funds already held by
+    /// this contract.
+    /// @dev External (not internal) because `_coreSwap` invokes it as
+    /// `this._dispatchVenue(...)` to wrap the venue call in a try/catch — only
+    /// external calls produce a catchable frame, and a revert there also rolls
+    /// back the per-venue `forceApprove` issued below. The router must already
+    /// hold `amountIn` of `tokenIn`; this function approves the selected venue
+    /// for `amountIn` and the venue pulls during its own swap. Gated on
+    /// `msg.sender == address(this)` so only the self-call from `_coreSwap` can
+    /// enter (reverts `OnlySelf` otherwise). After the venue call, measures the
+    /// delivered delta on `recipient` and reverts if it is below `amountOutMin`
+    /// — by reverting (rather than returning a thin amount) the under-fill is
+    /// caught by the outer try/catch in `_coreSwap` and triggers the Uniswap V3
+    /// fallback. Reverts `UnknownVenue` for non-whitelisted addresses, or
+    /// bubbles up the underlying proprietary router's revert.
+    /// @param venue The proprietary venue to route the swap through.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -192,12 +248,12 @@ contract PropAMMRouter is
     /// @param deadline Unix timestamp after which the swap is no longer valid;
     /// only honored by venues that enforce it (e.g. Bebop).
     /// @param prevTokenOutBalance `recipient`'s `tokenOut` balance snapshotted
-    /// by `swap` before this call, passed through so the delivered delta can
-    /// be computed without re-reading the pre-balance.
+    /// by `_coreSwap` before this call, passed through so the delivered delta
+    /// can be computed without re-reading the pre-balance.
     /// @return amountOut The amount of `tokenOut` delivered to `recipient`,
     /// measured as the balance delta against `prevTokenOutBalance`.
-    function swapViaVenue(
-        Venue venue,
+    function _dispatchVenue(
+        address venue,
         address tokenIn,
         address tokenOut,
         uint256 amountIn,
@@ -205,22 +261,10 @@ contract PropAMMRouter is
         address recipient,
         uint256 deadline,
         uint256 prevTokenOutBalance
-    ) external returns (uint256) {
+    ) external returns (uint256 amountOut) {
         require(msg.sender == address(this), OnlySelf());
 
-        if (venue == Venue.Fallback) {
-            // Caller explicitly chose Uniswap V3. Rather than running the
-            // fallback inline here, we revert so `swap`'s existing
-            // try/catch arm executes the Uniswap V3 path. This funnels both
-            // "proprietary venue failed" and "caller asked for Fallback"
-            // through one code path — same forceApprove reset, same
-            // post-swap balance delta, same `InsufficientOutput` check —
-            // at the cost of one wasted self-call frame on the explicit
-            // Fallback path. The bare `revert()` carries no data; `swap`'s
-            // catch arm is data-agnostic, so the empty payload is fine and
-            // saves the gas of encoding a custom error.
-            revert();
-        } else if (venue == Venue.FermiSwap) {
+        if (venue == FERMI_ROUTER) {
             IERC20(tokenIn).forceApprove(FERMI_ROUTER, amountIn);
             int256 _amountIn = amountIn.toInt256();
             IFermiSwapper(FERMI_ROUTER).fermiSwapWithAllowances(
@@ -233,7 +277,7 @@ contract PropAMMRouter is
 
             // Prevent later transfers if token was partially pulled
             IERC20(tokenIn).forceApprove(FERMI_ROUTER, 0);
-        } else if (venue == Venue.Kipseli) {
+        } else if (venue == KIPSELI_PAMM) {
             IERC20(tokenIn).safeTransfer(KIPSELI_PAMM, amountIn);
             uint256 amountOut_ = IKipseliPAMM(KIPSELI_PAMM).swap(
                 tokenIn,
@@ -243,11 +287,11 @@ contract PropAMMRouter is
             );
 
             // Kipseli signals failure by returning 0 and keeping `tokenIn`; revert
-            // to roll back its transferFrom and let the catch arm engage the fallback.
+            // to roll back its transfer and let the catch arm engage the fallback.
             if (amountOut_ == 0) {
                 revert();
             }
-        } else if (venue == Venue.Bebop) {
+        } else if (venue == BEBOP_ROUTER) {
             uint256 balanceTokenOutBefore = IERC20(tokenOut).balanceOf(
                 address(this)
             );
@@ -268,7 +312,10 @@ contract PropAMMRouter is
             // router, so it is required to transfer the received tokens
             // to the actual recipient
             uint256 balanceTokenOut = IERC20(tokenOut).balanceOf(address(this));
-            require(balanceTokenOut >= balanceTokenOutBefore, TokenOutBalanceDecreased());
+            require(
+                balanceTokenOut >= balanceTokenOutBefore,
+                TokenOutBalanceDecreased()
+            );
             uint256 received = balanceTokenOut - balanceTokenOutBefore;
             if (received > 0 && recipient != address(this)) {
                 IERC20(tokenOut).safeTransfer(recipient, received);
@@ -277,8 +324,7 @@ contract PropAMMRouter is
             revert UnknownVenue();
         }
 
-        uint256 amountOut = IERC20(tokenOut).balanceOf(recipient) -
-            prevTokenOutBalance;
+        amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         if (amountOut < amountOutMin) {
             revert();
         }
@@ -289,14 +335,13 @@ contract PropAMMRouter is
     /// @notice Executes the fallback swap on Uniswap V3 with funds already held
     /// by this contract.
     /// @dev Assumes the router already holds `amountIn` of `tokenIn` — pulled
-    /// once by `swap` before the try/catch. `UniV3Router.swapExactIn` only
-    /// approves `fallbackSwapRouter` and executes the swap; it does not pull
-    /// from `msg.sender`.
+    /// once by `_coreSwap` before the try/catch. Uses the owner-set `fallbackFee`
+    /// pool tier. `UniV3Router.swapExactIn` only approves `fallbackSwapRouter`
+    /// and executes the swap; it does not pull from `msg.sender`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
     /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
-    /// @param fee The Uniswap V3 pool fee tier (in hundredths of a bip).
     /// @param recipient The address that will receive `tokenOut`.
     /// @return amountOut The amount of `tokenOut` received by `recipient`.
     function swapViaUniswapV3(
@@ -304,13 +349,12 @@ contract PropAMMRouter is
         address tokenOut,
         uint256 amountIn,
         uint256 amountOutMin,
-        uint24 fee,
         address recipient
     ) private returns (uint256 amountOut) {
         amountOut = UniV3Router.swapExactIn(
             tokenIn,
             tokenOut,
-            fee,
+            fallbackFee,
             amountIn,
             amountOutMin,
             recipient,
@@ -320,81 +364,38 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Queries each venue via try/catch. Fermi, Kipseli, and Bebop each
-    /// expose their own on-chain quote (Kipseli via the dedicated
-    /// `IKipseliQuoter.preSwapQuote` contract). The Fallback branch queries
-    /// Uniswap V3's QuoterV2 at `uniswapFee`, which prices via revert-based
-    /// simulation — so `quote` is not `view` and should be called via
-    /// `eth_call` (staticcall) from off-chain.
-    /// Reverts `NoQuotesAvailable` if every venue is skipped or reverts.
-    function quote(
+    /// @dev Delegates to `_pickBestVenue` (which compares the proprietary AMMs
+    /// and the Uniswap V3 baseline) and reverts `NoQuotesAvailable` if nothing
+    /// could be priced.
+    function quoteV1(
         address tokenIn,
         address tokenOut,
-        uint256 amount,
-        uint24 uniswapFee
-    ) public returns (uint256 bestQuote, Venue venue) {
-        for (uint256 i = 0; i <= uint256(type(Venue).max); i++) {
-            try
-                this.quoteVenue(Venue(i), tokenIn, tokenOut, amount, uniswapFee)
-            returns (uint256 amountOut) {
-                if (amountOut > bestQuote) {
-                    bestQuote = amountOut;
-                    venue = Venue(i);
-                }
-            } catch {}
-        }
-
+        uint256 amount
+    ) public returns (uint256 bestQuote, address venue) {
+        (bestQuote, venue) = _pickBestVenue(tokenIn, tokenOut, amount);
         require(bestQuote > 0, NoQuotesAvailable());
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Forwards to the explicit-fee overload using
-    /// `DEFAULT_FALLBACK_FEE` for the Uniswap V3 fallback branch.
-    function quote(
+    /// @dev Dispatches by address across the whitelisted proprietary AMMs only.
+    /// Kipseli is quoted via the dedicated `IKipseliQuoter.preSwapQuote` contract
+    /// rather than the swap wrapper to save gas. Uniswap V3 is intentionally not
+    /// quotable here — it is only surfaced through `quoteV1`. Reverts
+    /// `UnknownVenue` for any non-whitelisted address.
+    function quoteVenueV1(
+        address venue,
         address tokenIn,
         address tokenOut,
         uint256 amount
-    ) external returns (uint256 bestQuote, Venue venue) {
-        return quote(tokenIn, tokenOut, amount, DEFAULT_FALLBACK_FEE);
-    }
-
-    /// @inheritdoc IPropAMMRouter
-    /// @dev Queries the given venue's quote.
-    /// `Venue.Fallback` is priced via Uniswap V3's QuoterV2 at `uniswapFee`, 
-    /// which simulates via revert and makes this function non-`view`. Should be called via
-    /// `eth_call` (staticcall) from off-chain. Reverts `UnknownVenue` if the
-    /// given venue is unrecognized.
-    function quoteVenue(
-        Venue venue,
-        address tokenIn,
-        address tokenOut,
-        uint256 amount,
-        uint24 uniswapFee
     ) public returns (uint256 amountOut) {
-        if (venue == Venue.Fallback) {
-            amountOut = UniV3Router.quoteExactIn(
-                tokenIn,
-                tokenOut,
-                uniswapFee,
-                amount,
-                fallbackQuoter
-            );
-        } else if (venue == Venue.FermiSwap) {
+        if (venue == FERMI_ROUTER) {
             int256 amountInt256 = amount.toInt256();
             (, amountOut) = IFermiSwapper(FERMI_ROUTER).quoteAmounts(
                 tokenIn,
                 tokenOut,
                 amountInt256
             );
-        } else if (venue == Venue.Bebop) {
-            amountOut = IBebopRouter(BEBOP_ROUTER).quote(
-                tokenIn,
-                tokenOut,
-                amount
-            );
-        } else if (venue == Venue.Kipseli) {
-            // Call the Kipseli quoter directly instead of 
-            // going through the Kipseli swap wrapper to save gas
+        } else if (venue == KIPSELI_PAMM) {
             amountOut = IKipseliQuoter(KIPSELI_QUOTER).preSwapQuote(
                 tokenIn,
                 amount,
@@ -402,34 +403,113 @@ contract PropAMMRouter is
                 block.timestamp * 1000,
                 address(0)
             );
+        } else if (venue == BEBOP_ROUTER) {
+            amountOut = IBebopRouter(BEBOP_ROUTER).quote(
+                tokenIn,
+                tokenOut,
+                amount
+            );
         } else {
             revert UnknownVenue();
         }
     }
 
-    /// @inheritdoc IPropAMMRouter
-    /// @dev Forwards to the explicit-fee overload using
-    /// `DEFAULT_FALLBACK_FEE` for the Uniswap V3 fallback branch.
-    function quoteVenue(
-        Venue venue,
+    /// @notice Quotes the Uniswap V3 baseline for the pair at the current
+    /// `fallbackFee` tier.
+    /// @dev External so `_pickBestVenue` and `quoteV1` can wrap it in a
+    /// `try/catch` (an internal library call can't be caught). Not `view`:
+    /// QuoterV2 prices via revert-based simulation. Call off-chain via
+    /// `eth_call` (staticcall).
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return amountOut The amount of `tokenOut` the Uniswap V3 swap would produce.
+    function quoteUniswapV3(
         address tokenIn,
         address tokenOut,
         uint256 amount
     ) external returns (uint256 amountOut) {
         return
-            quoteVenue(venue, tokenIn, tokenOut, amount, DEFAULT_FALLBACK_FEE);
+            UniV3Router.quoteExactIn(
+                tokenIn,
+                tokenOut,
+                fallbackFee,
+                amount,
+                fallbackQuoter
+            );
+    }
+
+    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
+    /// `tokenIn` across the proprietary AMMs and the Uniswap V3 baseline.
+    /// @dev Each venue is queried in its own `try/catch` so a reverting venue is
+    /// simply skipped. Returns `(0, address(0))` when nothing can be priced —
+    /// callers that need a hard failure (e.g. `quoteV1`) check for that;
+    /// `swapV1` instead lets `_coreSwap` route the `address(0)` case to Uniswap.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return bestQuote The best `tokenOut` amount found across all venues.
+    /// @return venue The venue that produced `bestQuote`; `fallbackSwapRouter`
+    /// if the Uniswap V3 baseline won.
+    function _pickBestVenue(
+        address tokenIn,
+        address tokenOut,
+        uint256 amount
+    ) internal returns (uint256 bestQuote, address venue) {
+        address[3] memory venues = [FERMI_ROUTER, KIPSELI_PAMM, BEBOP_ROUTER];
+        for (uint256 i = 0; i < venues.length; i++) {
+            try this.quoteVenueV1(venues[i], tokenIn, tokenOut, amount) returns (
+                uint256 amountOut
+            ) {
+                if (amountOut > bestQuote) {
+                    bestQuote = amountOut;
+                    venue = venues[i];
+                }
+            } catch {}
+        }
+
+        // Uniswap V3 is a baseline candidate, addressed by its SwapRouter.
+        try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (
+            uint256 amountOut
+        ) {
+            if (amountOut > bestQuote) {
+                bestQuote = amountOut;
+                venue = fallbackSwapRouter;
+            }
+        } catch {}
+    }
+
+    /// @notice Returns whether `venue` is a whitelisted proprietary AMM that a
+    /// caller may name explicitly in `quoteVenueV1` / `swapViaVenueV1`.
+    /// @dev The whitelist is the three hardcoded proprietary routers. Uniswap V3
+    /// is deliberately excluded — it is reachable only via `swapV1`'s best-quote
+    /// selection or as the failure fallback.
+    function _isVenue(address venue) private pure returns (bool) {
+        return
+            venue == FERMI_ROUTER ||
+            venue == KIPSELI_PAMM ||
+            venue == BEBOP_ROUTER;
     }
 
     /// @dev Restricts UUPS upgrades to the contract owner set in `initialize`.
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    /// @notice Pauses `swap`, blocking new swaps until `unpause` is called.
+    /// @notice Sets the Uniswap V3 pool fee tier used by the fallback route.
+    /// @dev Owner-gated. Lets the deepest pool for the traded pairs be selected
+    /// without a contract upgrade.
+    /// @param fee The Uniswap V3 fee tier in hundredths of a bip (e.g. `3000`
+    /// for 0.30%).
+    function setFallbackFee(uint24 fee) external onlyOwner {
+        fallbackFee = fee;
+    }
+
+    /// @notice Pauses swaps, blocking new swaps until `unpause` is called.
     /// @dev Owner-gated. Quote functions remain callable while paused.
     function pause() external onlyOwner {
         _pause();
     }
 
-    /// @notice Unpauses `swap`.
+    /// @notice Unpauses swaps.
     function unpause() external onlyOwner {
         _unpause();
     }

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -105,8 +105,9 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Picks the best-quoting venue via `_pickBestVenue`, then executes
-    /// through `_coreSwap`; an `address(0)` selection (no venue could quote)
-    /// routes straight to the Uniswap fallback. Reverts `QuoteBelowMinimum`
+    /// through `_coreSwap`; a `fallbackSwapRouter` selection (the Uniswap
+    /// baseline won, or no venue could quote) routes straight to the Uniswap
+    /// fallback. Reverts `QuoteBelowMinimum`
     /// before pulling funds when the best quote is under `amountOutMin`. Quotes
     /// are advisory, so `_coreSwap` re-checks `amountOutMin` against the
     /// delivered balance delta.
@@ -148,14 +149,14 @@ contract PropAMMRouter is
     /// from `msg.sender`, snapshots `recipient`'s `tokenOut` balance, then:
     /// for a proprietary `venue`, wraps the venue call in `try this._dispatchVenue`
     /// so a revert (including an under-fill, which `_dispatchVenue` turns into a
-    /// revert) is caught and recovered on Uniswap V3; for `address(0)` (no
-    /// proprietary venue selected, or the Uniswap baseline was best) it runs
+    /// revert) is caught and recovered on Uniswap V3; for `fallbackSwapRouter`
+    /// (no proprietary venue selected, or the Uniswap baseline was best) it runs
     /// Uniswap V3 directly. The external self-call is intentional: only an
     /// external call produces a catchable frame and rolls back the venue's
     /// `forceApprove`. The Uniswap branch re-measures the delivered delta and
     /// enforces `amountOutMin` to defend against an under-delivering router.
-    /// @param venue The proprietary AMM to attempt first, or `address(0)` to go
-    /// straight to the Uniswap V3 fallback.
+    /// @param venue The proprietary AMM to attempt first, or `fallbackSwapRouter`
+    /// to go straight to the Uniswap V3 fallback.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -164,7 +165,7 @@ contract PropAMMRouter is
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` delivered to `recipient`.
     /// @return executedVenue The proprietary AMM that filled the swap, or
-    /// `address(0)` when the Uniswap V3 fallback ran.
+    /// `fallbackSwapRouter` when the Uniswap V3 fallback ran.
     function _coreSwap(
         address venue,
         address tokenIn,
@@ -179,7 +180,7 @@ contract PropAMMRouter is
 
         uint256 prevTokenOutBalance = IERC20(tokenOut).balanceOf(recipient);
 
-        if (venue != address(0)) {
+        if (venue != fallbackSwapRouter) {
             try this._dispatchVenue(
                 venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline, prevTokenOutBalance
             ) returns (
@@ -194,7 +195,7 @@ contract PropAMMRouter is
         swapViaUniswapV3(tokenIn, tokenOut, amountIn, amountOutMin, recipient);
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         require(amountOut >= amountOutMin, InsufficientOutput(amountOutMin, amountOut));
-        return (amountOut, address(0));
+        return (amountOut, fallbackSwapRouter);
     }
 
     /// @notice Executes a swap on a proprietary venue with funds already held by
@@ -361,22 +362,30 @@ contract PropAMMRouter is
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of
     /// `tokenIn` across the proprietary AMMs and the Uniswap V3 baseline.
     /// @dev Each venue is queried in its own `try/catch` so a reverting venue is
-    /// simply skipped. Returns `(0, address(0))` when nothing can be priced —
-    /// callers that need a hard failure (e.g. `quoteV1`) check for that;
-    /// `swapV1` instead lets `_coreSwap` route the `address(0)` case to Uniswap.
-    /// Every non-zero `venue` returned here is one of the whitelisted
-    /// proprietary AMMs, so it is always accepted by `swapViaVenueV1` /
-    /// `quoteVenueV1`.
+    /// simply skipped. Returns `(0, fallbackSwapRouter)` when nothing can be
+    /// priced — callers that need a hard failure (e.g. `quoteV1`) check the
+    /// zero quote; `swapV1` instead lets `_coreSwap` route the
+    /// `fallbackSwapRouter` case to Uniswap. The returned `venue` is one of the
+    /// whitelisted proprietary AMMs or `fallbackSwapRouter`; the latter is
+    /// rejected by `swapViaVenueV1` / `quoteVenueV1` but consumed only by
+    /// `_coreSwap` (via `swapV1`), which treats it as the Uniswap baseline.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount found across all venues.
     /// @return venue The proprietary AMM that produced `bestQuote`, or
-    /// `address(0)` if the Uniswap V3 baseline won (or nothing could be priced).
+    /// `fallbackSwapRouter` if the Uniswap V3 baseline won (or nothing could be
+    /// priced).
     function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
         internal
         returns (uint256 bestQuote, address venue)
     {
+        // Uniswap V3 is the always-present baseline, so seed the winner with
+        // its SwapRouter02 address. A proprietary venue overtakes it only by
+        // quoting strictly more; if none do (or nothing can be priced at all),
+        // `venue` stays `fallbackSwapRouter` and `_coreSwap` routes to Uniswap.
+        venue = fallbackSwapRouter;
+
         address[3] memory venues = [FERMI_ROUTER, KIPSELI_PAMM, BEBOP_ROUTER];
         for (uint256 i = 0; i < venues.length; i++) {
             try this.quoteVenueV1(venues[i], tokenIn, tokenOut, amount) returns (uint256 amountOut) {
@@ -388,12 +397,13 @@ contract PropAMMRouter is
         }
 
         // Uniswap V3 is a baseline candidate but not a nameable venue: when it
-        // wins, `venue` stays `address(0)` so the result is never an address
-        // that `swapViaVenueV1` / `quoteVenueV1` would reject.
+        // wins, `venue` is `fallbackSwapRouter`, which `swapViaVenueV1` /
+        // `quoteVenueV1` reject — but that result is consumed only by
+        // `_coreSwap` (via `swapV1`), which treats it as the Uniswap baseline.
         try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
-                venue = address(0);
+                venue = fallbackSwapRouter;
             }
         } catch {}
     }

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -17,19 +17,10 @@ import {KIPSELI_QUOTER, IKipseliQuoter} from "./interfaces/IKipseliQuoter.sol";
 import {UniV3Router} from "./libraries/UniV3Router.sol";
 
 /// @title PropAMMRouter
-/// @notice Routes single-hop swaps to a proprietary AMM (FermiSwap, Kipseli, or
-/// Bebop) and falls back to Uniswap V3 if the chosen proprietary venue reverts.
+/// @notice Routes single-hop swaps to a propAMM and falls back through a fallback 
+/// venue if the chosen venue reverts.
 /// @dev Designed to live behind a UUPS proxy. The fallback path is wired at
-/// initialization via `fallbackSwapRouter` (SwapRouter02) and `fallbackQuoter`
-/// (QuoterV2); proprietary venue addresses are hardcoded as constants. Venues
-/// are identified by address: the venues a caller may name explicitly are the
-/// three proprietary AMMs plus Uniswap V3 (see `_isVenue`), the latter named by
-/// the `fallbackSwapRouter` (SwapRouter02) address. Uniswap V3 is also folded
-/// into `quoteV1` as a fallback candidate and is reached automatically (best-quote
-/// selection in `swapV1`, or as the failure fallback when a proprietary venue
-/// reverts). The Uniswap fee tier is the owner-settable `fallbackFee`, so
-/// callers never pass one. The owner authorized in `initialize` controls
-/// upgrades via `_authorizeUpgrade`.
+/// initialization via `fallbackSwapRouter` and `fallbackQuoter`
 contract PropAMMRouter is
     IPropAMMRouter,
     ReentrancyGuardTransient,
@@ -41,18 +32,13 @@ contract PropAMMRouter is
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
-    /// @notice Uniswap V3 SwapRouter02 used when the proprietary AMM swap
-    /// reverts. Also the sentinel that identifies the Uniswap venue (see
-    /// `_isVenue`). Owner-settable via `setFallbackSwapRouter` so a new
-    /// SwapRouter deployment can be adopted without a contract upgrade.
+    /// @notice Fallback venue address. 
+    /// Owner-settable via `setFallbackSwapRouter`.
     address public fallbackSwapRouter;
-    /// @notice Uniswap V3 QuoterV2 used to price the fallback route off-chain.
-    /// Owner-settable via `setFallbackQuoter` so a new QuoterV2 deployment can
-    /// be adopted without a contract upgrade.
+    /// @notice Fallback venue address used to price the fallback route.
+    /// Owner-settable via `setFallbackQuoter`.
     address public fallbackQuoter;
-    /// @notice Uniswap V3 pool fee tier (in hundredths of a bip) used for the
-    /// Uniswap fallback quote and swap. `3000` = 0.30% by default; the owner can
-    /// retune it via `setFallbackFee` without a contract upgrade.
+    /// @notice Fee for the fallback venue.
     uint24 public fallbackFee;
 
     /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
@@ -82,9 +68,7 @@ contract PropAMMRouter is
     error NoQuotesAvailable();
     /// @notice Thrown when `tokenOut` balance decreases after a swap.
     error TokenOutBalanceDecreased();
-    /// @notice Thrown when a Uniswap V3 fee tier is invalid: `0` (which resolves
-    /// to no pool and would brick the fallback) or at/above the factory's
-    /// `1_000_000` (100%) cap.
+    /// @notice Thrown when a fallback fee is invalid.
     error InvalidFallbackFee(uint24 fee);
     /// @notice Thrown when an address argument that must be non-zero is zero.
     error ZeroAddress();
@@ -93,15 +77,15 @@ contract PropAMMRouter is
     // and inherited here. The operational events below are implementation
     // detail and stay contract-local.
 
-    /// @notice Emitted when the owner retunes the Uniswap V3 fallback fee tier.
+    /// @notice Emitted when the owner updates the fallback venue fee.
     /// @param oldFee The previous `fallbackFee`.
     /// @param newFee The new `fallbackFee`.
     event FallbackFeeUpdated(uint24 oldFee, uint24 newFee);
-    /// @notice Emitted when the owner repoints the Uniswap V3 SwapRouter02.
+    /// @notice Emitted when the owner updates the fallback venue address.
     /// @param oldRouter The previous `fallbackSwapRouter`.
     /// @param newRouter The new `fallbackSwapRouter`.
     event FallbackSwapRouterUpdated(address indexed oldRouter, address indexed newRouter);
-    /// @notice Emitted when the owner repoints the Uniswap V3 QuoterV2.
+    /// @notice Emitted when the owner updates the fallback quoter address.
     /// @param oldQuoter The previous `fallbackQuoter`.
     /// @param newQuoter The new `fallbackQuoter`.
     event FallbackQuoterUpdated(address indexed oldQuoter, address indexed newQuoter);
@@ -116,13 +100,13 @@ contract PropAMMRouter is
         _disableInitializers();
     }
 
-    /// @notice Initializes the router, pinning the Uniswap V3 fallback contracts
+    /// @notice Initializes the router, pinning fallback venue address
     /// and setting the owner who controls future upgrades.
-    /// @param fallbackSwapRouter_ Address of the Uniswap V3 SwapRouter02 used
+    /// @param fallbackSwapRouter_ Address of fallback router used
     /// to execute the fallback swap. Reverts `ZeroAddress` if zero — it also
-    /// doubles as the Uniswap venue sentinel, so a zero value would corrupt
+    /// doubles as the fallback venue sentinel, so a zero value would corrupt
     /// venue identity (`_isVenue`, `_pickBestVenue`, `_coreSwap`).
-    /// @param fallbackQuoter_ Address of the Uniswap V3 QuoterV2 used to quote
+    /// @param fallbackQuoter_ Address of the fallback quoter used to quote
     /// the fallback swap off-chain. Reverts `ZeroAddress` if zero.
     /// @param owner_ Initial owner of the proxy. Set directly here with no
     /// acceptance step — `Ownable2Step`'s two-step handoff only governs
@@ -143,7 +127,7 @@ contract PropAMMRouter is
     /// @inheritdoc IPropAMMRouter
     /// @dev Picks the best-quoting venue via `_pickBestVenue`, then executes
     /// through `_coreSwap`; a `fallbackSwapRouter` selection (the Uniswap
-    /// fallback won, or no venue could quote) routes straight to Uniswap V3.
+    /// fallback won, or no venue could quote) routes straight to the fallback venue.
     /// Reverts `QuoteBelowMinimum`
     /// before pulling funds when the best quote is under `amountOutMin`. Quotes
     /// are advisory, so `_coreSwap` re-checks `amountOutMin` against the
@@ -165,11 +149,8 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev `venue` must be a callable venue (`_isVenue`): one of the three
-    /// proprietary AMMs or the Uniswap V3 fallback, named by the
-    /// `fallbackSwapRouter` address. Naming Uniswap runs it directly via
-    /// `_coreSwap`'s `fallbackSwapRouter` path (no proprietary attempt); a
-    /// proprietary `venue` still recovers on Uniswap if it fails to fill.
+    /// @dev Swaps via the `venue`. It must be a callable venue or the 
+    /// fallback venue named by the `fallbackSwapRouter` address.
     function swapViaVenueV1(
         address venue,
         address tokenIn,
@@ -186,13 +167,10 @@ contract PropAMMRouter is
     /// @inheritdoc IPropAMMRouter
     /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
     /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with
-    /// `swapV1`, the Uniswap V3 fallback remains the transparent safety net
-    /// inside `_coreSwap` (a chosen proprietary venue recovers on Uniswap if it
-    /// fails to fill); it is not a selection candidate unless the caller lists
-    /// the `fallbackSwapRouter` address. Reverts `NoQuotesAvailable` if none of
-    /// `venues` can be priced, and `QuoteBelowMinimum` before pulling funds when
-    /// the best quote across `venues` is under `amountOutMin`; quotes are
-    /// advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
+    /// `swapV1`, the fallback remains as the transparent safety net inside `_coreSwap`.
+    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and `QuoteBelowMinimum` 
+    /// before pulling funds when the best quote across `venues` is under `amountOutMin`; 
+    /// quotes are advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
     /// balance delta.
     function swapViaSelectedVenuesV1(
         address[] calldata venues,
@@ -206,33 +184,18 @@ contract PropAMMRouter is
         // Fail fast before the on-chain requote; `_coreSwap` re-checks deadline.
         require(block.timestamp <= deadline, Expired());
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
-        // Reject when none of the selected venues could be priced (venue stays
-        // address(0)). Without this, an `amountOutMin == 0` call would slip past
-        // the QuoteBelowMinimum check and silently route to the Uniswap fallback
-        // the caller never selected. Mirrors `quoteSelectedVenuesV1`. A selected
-        // venue that quotes but then fails to fill still recovers on Uniswap
-        // inside `_coreSwap` — that transparent fallback is unaffected.
+        // Reject when none of the selected venues could be priced (venue stays address(0)).
         require(venue != address(0), NoQuotesAvailable());
         require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
         return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 
     /// @notice Pulls funds once and executes a swap, attempting `venue` first
-    /// and recovering on Uniswap V3 if it fails.
+    /// and recovering via the fallback if it fails.
     /// @dev Shared core for `swapV1` and `swapViaVenueV1`; unguarded so the two
     /// public entrypoints can each apply `whenNotPaused`/`nonReentrant` without
-    /// re-entering the guard through one another. Pulls `amountIn` of `tokenIn`
-    /// from `msg.sender`, snapshots `recipient`'s `tokenOut` balance, then:
-    /// for a proprietary `venue`, wraps the venue call in `try this._dispatchVenue`
-    /// so a revert (including an under-fill, which `_dispatchVenue` turns into a
-    /// revert) is caught and recovered on Uniswap V3; for `fallbackSwapRouter`
-    /// (no proprietary venue selected, or the Uniswap fallback was best) it runs
-    /// Uniswap V3 directly. The external self-call is intentional: only an
-    /// external call produces a catchable frame and rolls back the venue's
-    /// `forceApprove`. The Uniswap branch re-measures the delivered delta and
-    /// enforces `amountOutMin` to defend against an under-delivering router.
-    /// @param venue The proprietary AMM to attempt first, or `fallbackSwapRouter`
-    /// to go straight to the Uniswap V3 fallback.
+    /// re-entering the guard through one another. 
+    /// @param venue The propAMM to attempt first, or `fallbackSwapRouter`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -240,8 +203,8 @@ contract PropAMMRouter is
     /// @param recipient The address that will receive `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` delivered to `recipient`.
-    /// @return executedVenue The proprietary AMM that filled the swap, or
-    /// `fallbackSwapRouter` when the Uniswap V3 fallback ran.
+    /// @return executedVenue The propAMM that filled the swap, or
+    /// `fallbackSwapRouter` when the fallback ran.
     function _coreSwap(
         address venue,
         address tokenIn,
@@ -302,22 +265,10 @@ contract PropAMMRouter is
         emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient, marketMaker);
     }
 
-    /// @notice Executes a swap on a proprietary venue with funds already held by
-    /// this contract.
-    /// @dev External (not internal) because `_coreSwap` invokes it as
-    /// `this._dispatchVenue(...)` to wrap the venue call in a try/catch — only
-    /// external calls produce a catchable frame, and a revert there also rolls
-    /// back the per-venue `forceApprove` issued below. The router must already
-    /// hold `amountIn` of `tokenIn`; this function approves the selected venue
-    /// for `amountIn` and the venue pulls during its own swap. Gated on
-    /// `msg.sender == address(this)` so only the self-call from `_coreSwap` can
-    /// enter (reverts `OnlySelf` otherwise). After the venue call, measures the
-    /// delivered delta on `recipient` and reverts if it is below `amountOutMin`
-    /// — by reverting (rather than returning a thin amount) the under-fill is
-    /// caught by the outer try/catch in `_coreSwap` and triggers the Uniswap V3
-    /// fallback. Reverts `UnknownVenue` for non-whitelisted addresses, or
-    /// bubbles up the underlying proprietary router's revert.
-    /// @param venue The proprietary venue to route the swap through.
+    /// @notice Executes a swap on a venue with funds already held by this contract.
+    /// @dev Reverts `UnknownVenue` for non-whitelisted addresses, or
+    /// bubbles up the underlying propAMM router's revert.
+    /// @param venue The venue to route the swap through.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -416,8 +367,7 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Delegates to `_pickBestVenue` (which compares the proprietary AMMs
-    /// and the Uniswap V3 fallback) and reverts `NoQuotesAvailable` if nothing
-    /// could be priced.
+    /// and fallback) and reverts `NoQuotesAvailable` if nothing could be priced.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         public
         returns (uint256 bestQuote, address venue)
@@ -427,11 +377,8 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Dispatches by address across the three proprietary AMMs plus the
-    /// Uniswap V3 fallback (named by the `fallbackSwapRouter` address). Kipseli is
-    /// quoted via the dedicated `IKipseliQuoter.preSwapQuote` contract rather than
-    /// the swap wrapper to save gas; Uniswap V3 is priced via QuoterV2 at the
-    /// owner-set `fallbackFee` tier. Reverts `UnknownVenue` for any other address.
+    /// @dev Dispatches by address across the propAMMs and the fallback.
+    /// Reverts `UnknownVenue` for any other address.
     function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
         public
         returns (uint256 amountOut)
@@ -456,8 +403,6 @@ contract PropAMMRouter is
     /// reverts `NoQuotesAvailable` if none of them can be priced. Venues that
     /// revert while quoting — including non-whitelisted addresses, which
     /// `quoteVenueV1` rejects with `UnknownVenue` — are skipped, not surfaced.
-    /// Not `view` (the Kipseli/Uniswap branches price via revert-based
-    /// simulation); call via `eth_call` (staticcall) off-chain.
     function quoteSelectedVenuesV1(address[] calldata venues, address tokenIn, address tokenOut, uint256 amountIn)
         public
         returns (uint256 bestAmountOut, address bestVenue)
@@ -469,9 +414,7 @@ contract PropAMMRouter is
     /// @notice Quotes the Uniswap V3 fallback for the pair at the current
     /// `fallbackFee` tier.
     /// @dev External so `_pickBestVenue` and `quoteV1` can wrap it in a
-    /// `try/catch` (an internal library call can't be caught). Not `view`:
-    /// QuoterV2 prices via revert-based simulation. Call off-chain via
-    /// `eth_call` (staticcall).
+    /// `try/catch` (an internal library call can't be caught).
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
@@ -481,30 +424,24 @@ contract PropAMMRouter is
     }
 
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of
-    /// `tokenIn` across the proprietary AMMs and the Uniswap V3 fallback.
+    /// `tokenIn` across the propAMMs and the fallback.
     /// @dev Each venue is queried in its own `try/catch` so a reverting venue is
     /// simply skipped. Returns `(0, fallbackSwapRouter)` when nothing can be
     /// priced — callers that need a hard failure (e.g. `quoteV1`) check the
     /// zero quote; `swapV1` instead lets `_coreSwap` route the
-    /// `fallbackSwapRouter` case to Uniswap. The returned `venue` is one of the
-    /// whitelisted proprietary AMMs or `fallbackSwapRouter`; the latter is a
-    /// callable venue too (`swapViaVenueV1` / `quoteVenueV1` accept it) and is
-    /// also consumed by `_coreSwap` (via `swapV1`) as the Uniswap fallback.
+    /// `fallbackSwapRouter` to the fallback. The returned `venue` is one of the
+    /// whitelisted venues.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount found across all venues.
-    /// @return venue The venue that produced `bestQuote` — a proprietary AMM, or
-    /// `fallbackSwapRouter` if the Uniswap V3 fallback won (or nothing could be
-    /// priced).
+    /// @return venue The venue that produced `bestQuote`.
     function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
         internal
         returns (uint256 bestQuote, address venue)
     {
-        // Uniswap V3 is the always-present fallback, so seed the winner with
-        // its SwapRouter02 address. A proprietary venue overtakes it only by
-        // quoting strictly more; if none do (or nothing can be priced at all),
-        // `venue` stays `fallbackSwapRouter` and `_coreSwap` routes to Uniswap.
+        // A venue overtakes it only by quoting strictly more; if none do (or nothing can be priced at all),
+        // `venue` stays `fallbackSwapRouter` and `_coreSwap` routes to fallback.
         venue = fallbackSwapRouter;
 
         address[3] memory venues = [FERMI_ROUTER, KIPSELI_PAMM, BEBOP_ROUTER];
@@ -562,14 +499,6 @@ contract PropAMMRouter is
 
     /// @notice Returns whether `venue` is a venue a caller may name explicitly in
     /// `quoteVenueV1` / `swapViaVenueV1`.
-    /// @dev The callable set is the three hardcoded proprietary routers plus the
-    /// Uniswap V3 fallback, identified by the live `fallbackSwapRouter`
-    /// (SwapRouter02) address. `view` rather than `pure` because it reads that
-    /// storage address. Internal "is this proprietary?" logic instead keys on
-    /// `venue != fallbackSwapRouter` (see `_coreSwap`).
-    /// @dev `address(0)` is rejected explicitly: `initialize` already forbids a
-    /// zero `fallbackSwapRouter`, but this keeps "zero is never a venue" true at
-    /// the gate regardless of how storage was reached.
     function _isVenue(address venue) private view returns (bool) {
         if (venue == address(0)) return false;
         return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER || venue == fallbackSwapRouter;
@@ -578,36 +507,33 @@ contract PropAMMRouter is
     /// @dev Restricts UUPS upgrades to the contract owner set in `initialize`.
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
-    /// @notice Sets the Uniswap V3 pool fee tier used by the fallback route.
+    /// @notice Sets the fallback fee used by the fallback route.
     /// @dev Owner-gated. Lets the deepest pool for the traded pairs be selected
     /// without a contract upgrade.
-    /// @param fee The Uniswap V3 fee tier in hundredths of a bip (e.g. `3000`
-    /// for 0.30%).
+    /// @param fee in hundredths of a bip (e.g. `3000` for 0.30%).
     function setFallbackFee(uint24 fee) external onlyOwner {
         require(fee != 0 && fee < 1_000_000, InvalidFallbackFee(fee));
         emit FallbackFeeUpdated(fallbackFee, fee);
         fallbackFee = fee;
     }
 
-    /// @notice Repoints the Uniswap V3 SwapRouter02 used by the fallback route.
+    /// @notice Repoints the address used by the fallback route.
     /// @dev Owner-gated. Lets a new SwapRouter deployment be adopted without a
     /// contract upgrade. Reverts `ZeroAddress` if zero — this address also
-    /// identifies the Uniswap venue (`_isVenue`, `_pickBestVenue`, `_coreSwap`),
+    /// identifies the fallback venue (`_isVenue`, `_pickBestVenue`, `_coreSwap`),
     /// so a zero value would corrupt venue identity. Note that `executedVenue`
     /// values observed off-chain are only meaningful relative to the router's
     /// configuration at the time of the swap.
-    /// @param newRouter Address of the new Uniswap V3 SwapRouter02.
+    /// @param newRouter Address of thew new router.
     function setFallbackSwapRouter(address newRouter) external onlyOwner {
         require(newRouter != address(0), ZeroAddress());
         emit FallbackSwapRouterUpdated(fallbackSwapRouter, newRouter);
         fallbackSwapRouter = newRouter;
     }
 
-    /// @notice Repoints the Uniswap V3 QuoterV2 used to price the fallback route.
-    /// @dev Owner-gated. Lets a new QuoterV2 deployment be adopted without a
-    /// contract upgrade. Reverts `ZeroAddress` if zero (a zero quoter would make
-    /// every Uniswap quote revert and be silently dropped from selection).
-    /// @param newQuoter Address of the new Uniswap V3 QuoterV2.
+    /// @notice Repoints the fallback quoter used to price the fallback route.
+    /// @dev Owner-gated. Reverts `ZeroAddress` if zero.
+    /// @param newQuoter Address of the new fallback quoter.
     function setFallbackQuoter(address newQuoter) external onlyOwner {
         require(newQuoter != address(0), ZeroAddress());
         emit FallbackQuoterUpdated(fallbackQuoter, newQuoter);

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -63,6 +63,13 @@ contract PropAMMRouter is
     /// @param receivedAmount The actual amount of `tokenOut` delivered to
     /// `recipient`, measured as a balance delta against the pre-swap snapshot.
     error InsufficientOutput(uint256 expectedAmount, uint256 receivedAmount);
+    /// @notice Thrown by `swapV1` when the best quote across all venues is below
+    /// `amountOutMin`, rejecting the swap before any funds are pulled. Distinct
+    /// from `InsufficientOutput`, which signals a shortfall measured *after*
+    /// execution.
+    /// @param amountOutMin The caller's minimum acceptable amount of `tokenOut`.
+    /// @param bestQuote The best `tokenOut` amount any venue quoted.
+    error QuoteBelowMinimum(uint256 amountOutMin, uint256 bestQuote);
     /// @notice Thrown when a swap is invoked after its `deadline`.
     error Expired();
     /// @notice Thrown when no venue can produce a quote for the requested pair
@@ -105,6 +112,11 @@ contract PropAMMRouter is
     /// Uniswap V3 baseline via `_pickBestVenue`, then executes it through
     /// `_coreSwap`. If every venue fails to quote, `_pickBestVenue` yields
     /// `address(0)` and `_coreSwap` routes straight to the Uniswap fallback.
+    /// Fails fast with `QuoteBelowMinimum` when even the best quote (which spans
+    /// the proprietary venues and the Uniswap fallback at `fallbackFee`) is
+    /// under `amountOutMin`, rejecting a doomed swap before pulling funds and
+    /// running the venue/fallback path. Quotes are advisory, so `_coreSwap`
+    /// still enforces `amountOutMin` against the delivered balance delta.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -118,7 +130,15 @@ contract PropAMMRouter is
         nonReentrant
         returns (uint256 amountOut, address executedVenue)
     {
-        (, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
+        (uint256 bestQuote, address venue) = _pickBestVenue(
+            tokenIn,
+            tokenOut,
+            amountIn
+        );
+        require(
+            bestQuote >= amountOutMin,
+            QuoteBelowMinimum(amountOutMin, bestQuote)
+        );
         return
             _coreSwap(
                 venue,

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -22,11 +22,12 @@ import {UniV3Router} from "./libraries/UniV3Router.sol";
 /// @dev Designed to live behind a UUPS proxy. The fallback path is wired at
 /// initialization via `fallbackSwapRouter` (SwapRouter02) and `fallbackQuoter`
 /// (QuoterV2); proprietary venue addresses are hardcoded as constants. Venues
-/// are identified by address: the whitelist of venues a caller may name
-/// explicitly is exactly the three proprietary AMMs (see `_isVenue`). Uniswap V3
-/// is never named directly — it is folded into `quoteV1` as a baseline price and
-/// is reached automatically (best-quote selection in `swapV1`, or as the failure
-/// fallback). The Uniswap fee tier is the owner-settable `fallbackFee`, so
+/// are identified by address: the venues a caller may name explicitly are the
+/// three proprietary AMMs plus Uniswap V3 (see `_isVenue`), the latter named by
+/// the `fallbackSwapRouter` (SwapRouter02) address. Uniswap V3 is also folded
+/// into `quoteV1` as a baseline price and is reached automatically (best-quote
+/// selection in `swapV1`, or as the failure fallback when a proprietary venue
+/// reverts). The Uniswap fee tier is the owner-settable `fallbackFee`, so
 /// callers never pass one. The owner authorized in `initialize` controls
 /// upgrades via `_authorizeUpgrade`.
 contract PropAMMRouter is
@@ -125,9 +126,11 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev `venue` must be a whitelisted proprietary AMM (`_isVenue`); Uniswap
-    /// V3 cannot be named here and is only reached as the failure fallback
-    /// inside `_coreSwap`.
+    /// @dev `venue` must be a callable venue (`_isVenue`): one of the three
+    /// proprietary AMMs or the Uniswap V3 baseline, named by the
+    /// `fallbackSwapRouter` address. Naming Uniswap runs it directly via
+    /// `_coreSwap`'s `fallbackSwapRouter` path (no proprietary attempt); a
+    /// proprietary `venue` still recovers on Uniswap if it fails to fill.
     function swapViaVenueV1(
         address venue,
         address tokenIn,
@@ -323,11 +326,11 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Dispatches by address across the whitelisted proprietary AMMs only.
-    /// Kipseli is quoted via the dedicated `IKipseliQuoter.preSwapQuote` contract
-    /// rather than the swap wrapper to save gas. Uniswap V3 is intentionally not
-    /// quotable here — it is only surfaced through `quoteV1`. Reverts
-    /// `UnknownVenue` for any non-whitelisted address.
+    /// @dev Dispatches by address across the three proprietary AMMs plus the
+    /// Uniswap V3 baseline (named by the `fallbackSwapRouter` address). Kipseli is
+    /// quoted via the dedicated `IKipseliQuoter.preSwapQuote` contract rather than
+    /// the swap wrapper to save gas; Uniswap V3 is priced via QuoterV2 at the
+    /// owner-set `fallbackFee` tier. Reverts `UnknownVenue` for any other address.
     function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
         public
         returns (uint256 amountOut)
@@ -340,6 +343,8 @@ contract PropAMMRouter is
                 .preSwapQuote(tokenIn, amount, tokenOut, block.timestamp * 1000, address(0));
         } else if (venue == BEBOP_ROUTER) {
             amountOut = IBebopRouter(BEBOP_ROUTER).quote(tokenIn, tokenOut, amount);
+        } else if (venue == fallbackSwapRouter) {
+            amountOut = UniV3Router.quoteExactIn(tokenIn, tokenOut, fallbackFee, amount, fallbackQuoter);
         } else {
             revert UnknownVenue();
         }
@@ -366,14 +371,14 @@ contract PropAMMRouter is
     /// priced — callers that need a hard failure (e.g. `quoteV1`) check the
     /// zero quote; `swapV1` instead lets `_coreSwap` route the
     /// `fallbackSwapRouter` case to Uniswap. The returned `venue` is one of the
-    /// whitelisted proprietary AMMs or `fallbackSwapRouter`; the latter is
-    /// rejected by `swapViaVenueV1` / `quoteVenueV1` but consumed only by
-    /// `_coreSwap` (via `swapV1`), which treats it as the Uniswap baseline.
+    /// whitelisted proprietary AMMs or `fallbackSwapRouter`; the latter is a
+    /// callable venue too (`swapViaVenueV1` / `quoteVenueV1` accept it) and is
+    /// also consumed by `_coreSwap` (via `swapV1`) as the Uniswap baseline.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount found across all venues.
-    /// @return venue The proprietary AMM that produced `bestQuote`, or
+    /// @return venue The venue that produced `bestQuote` — a proprietary AMM, or
     /// `fallbackSwapRouter` if the Uniswap V3 baseline won (or nothing could be
     /// priced).
     function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
@@ -396,10 +401,10 @@ contract PropAMMRouter is
             } catch {}
         }
 
-        // Uniswap V3 is a baseline candidate but not a nameable venue: when it
-        // wins, `venue` is `fallbackSwapRouter`, which `swapViaVenueV1` /
-        // `quoteVenueV1` reject — but that result is consumed only by
-        // `_coreSwap` (via `swapV1`), which treats it as the Uniswap baseline.
+        // Uniswap V3 is the always-present baseline candidate: when it wins,
+        // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
+        // treats as the Uniswap baseline. Callers may also name that address
+        // directly through `swapViaVenueV1` / `quoteVenueV1`.
         try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
@@ -408,13 +413,15 @@ contract PropAMMRouter is
         } catch {}
     }
 
-    /// @notice Returns whether `venue` is a whitelisted proprietary AMM that a
-    /// caller may name explicitly in `quoteVenueV1` / `swapViaVenueV1`.
-    /// @dev The whitelist is the three hardcoded proprietary routers. Uniswap V3
-    /// is deliberately excluded — it is reachable only via `swapV1`'s best-quote
-    /// selection or as the failure fallback.
-    function _isVenue(address venue) private pure returns (bool) {
-        return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER;
+    /// @notice Returns whether `venue` is a venue a caller may name explicitly in
+    /// `quoteVenueV1` / `swapViaVenueV1`.
+    /// @dev The callable set is the three hardcoded proprietary routers plus the
+    /// Uniswap V3 baseline, identified by the live `fallbackSwapRouter`
+    /// (SwapRouter02) address. `view` rather than `pure` because it reads that
+    /// storage address. Internal "is this proprietary?" logic instead keys on
+    /// `venue != fallbackSwapRouter` (see `_coreSwap`).
+    function _isVenue(address venue) private view returns (bool) {
+        return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER || venue == fallbackSwapRouter;
     }
 
     /// @dev Restricts UUPS upgrades to the contract owner set in `initialize`.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -94,11 +94,7 @@ contract PropAMMRouter is
     /// *subsequent* transfers via `transferOwnership` / `acceptOwnership`.
     /// Controls `_authorizeUpgrade` and any owner-gated administrative paths.
     /// Reverts if zero (enforced by `__Ownable_init`).
-    function initialize(
-        address fallbackSwapRouter_,
-        address fallbackQuoter_,
-        address owner_
-    ) public initializer {
+    function initialize(address fallbackSwapRouter_, address fallbackQuoter_, address owner_) public initializer {
         fallbackSwapRouter = fallbackSwapRouter_;
         fallbackQuoter = fallbackQuoter_;
         fallbackFee = 3000;
@@ -124,31 +120,10 @@ contract PropAMMRouter is
         uint256 amountOutMin,
         address recipient,
         uint256 deadline
-    )
-        external
-        whenNotPaused
-        nonReentrant
-        returns (uint256 amountOut, address executedVenue)
-    {
-        (uint256 bestQuote, address venue) = _pickBestVenue(
-            tokenIn,
-            tokenOut,
-            amountIn
-        );
-        require(
-            bestQuote >= amountOutMin,
-            QuoteBelowMinimum(amountOutMin, bestQuote)
-        );
-        return
-            _coreSwap(
-                venue,
-                tokenIn,
-                tokenOut,
-                amountIn,
-                amountOutMin,
-                recipient,
-                deadline
-            );
+    ) external whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
+        (uint256 bestQuote, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
+        require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
+        return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 
     /// @inheritdoc IPropAMMRouter
@@ -165,15 +140,7 @@ contract PropAMMRouter is
         uint256 deadline
     ) public whenNotPaused nonReentrant returns (uint256 amountOut) {
         require(_isVenue(venue), UnknownVenue());
-        (amountOut, ) = _coreSwap(
-            venue,
-            tokenIn,
-            tokenOut,
-            amountIn,
-            amountOutMin,
-            recipient,
-            deadline
-        );
+        (amountOut,) = _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 
     /// @notice Pulls funds once and executes a swap, attempting `venue` first
@@ -216,18 +183,11 @@ contract PropAMMRouter is
         uint256 prevTokenOutBalance = IERC20(tokenOut).balanceOf(recipient);
 
         if (venue != address(0)) {
-            try
-                this._dispatchVenue(
-                    venue,
-                    tokenIn,
-                    tokenOut,
-                    amountIn,
-                    amountOutMin,
-                    recipient,
-                    deadline,
-                    prevTokenOutBalance
-                )
-            returns (uint256 amountOut_) {
+            try this._dispatchVenue(
+                venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline, prevTokenOutBalance
+            ) returns (
+                uint256 amountOut_
+            ) {
                 return (amountOut_, venue);
             } catch {
                 // Fall through to the Uniswap V3 fallback below.
@@ -236,10 +196,7 @@ contract PropAMMRouter is
 
         swapViaUniswapV3(tokenIn, tokenOut, amountIn, amountOutMin, recipient);
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
-        require(
-            amountOut >= amountOutMin,
-            InsufficientOutput(amountOutMin, amountOut)
-        );
+        require(amountOut >= amountOutMin, InsufficientOutput(amountOutMin, amountOut));
         return (amountOut, address(0));
     }
 
@@ -287,24 +244,13 @@ contract PropAMMRouter is
         if (venue == FERMI_ROUTER) {
             IERC20(tokenIn).forceApprove(FERMI_ROUTER, amountIn);
             int256 _amountIn = amountIn.toInt256();
-            IFermiSwapper(FERMI_ROUTER).fermiSwapWithAllowances(
-                tokenIn,
-                tokenOut,
-                _amountIn,
-                amountOutMin,
-                recipient
-            );
+            IFermiSwapper(FERMI_ROUTER).fermiSwapWithAllowances(tokenIn, tokenOut, _amountIn, amountOutMin, recipient);
 
             // Prevent later transfers if token was partially pulled
             IERC20(tokenIn).forceApprove(FERMI_ROUTER, 0);
         } else if (venue == KIPSELI_PAMM) {
             IERC20(tokenIn).safeTransfer(KIPSELI_PAMM, amountIn);
-            uint256 amountOut_ = IKipseliPAMM(KIPSELI_PAMM).swap(
-                tokenIn,
-                amountIn,
-                tokenOut,
-                recipient
-            );
+            uint256 amountOut_ = IKipseliPAMM(KIPSELI_PAMM).swap(tokenIn, amountIn, tokenOut, recipient);
 
             // Kipseli signals failure by returning 0 and keeping `tokenIn`; revert
             // to roll back its transfer and let the catch arm engage the fallback.
@@ -312,17 +258,9 @@ contract PropAMMRouter is
                 revert();
             }
         } else if (venue == BEBOP_ROUTER) {
-            uint256 balanceTokenOutBefore = IERC20(tokenOut).balanceOf(
-                address(this)
-            );
+            uint256 balanceTokenOutBefore = IERC20(tokenOut).balanceOf(address(this));
             IERC20(tokenIn).forceApprove(BEBOP_ROUTER, amountIn);
-            IBebopRouter(BEBOP_ROUTER).swap(
-                tokenIn,
-                tokenOut,
-                amountIn,
-                amountOutMin,
-                deadline
-            );
+            IBebopRouter(BEBOP_ROUTER).swap(tokenIn, tokenOut, amountIn, amountOutMin, deadline);
 
             // Prevent later transfers if token was partially pulled
             IERC20(tokenIn).forceApprove(BEBOP_ROUTER, 0);
@@ -332,10 +270,7 @@ contract PropAMMRouter is
             // router, so it is required to transfer the received tokens
             // to the actual recipient
             uint256 balanceTokenOut = IERC20(tokenOut).balanceOf(address(this));
-            require(
-                balanceTokenOut >= balanceTokenOutBefore,
-                TokenOutBalanceDecreased()
-            );
+            require(balanceTokenOut >= balanceTokenOutBefore, TokenOutBalanceDecreased());
             uint256 received = balanceTokenOut - balanceTokenOutBefore;
             if (received > 0 && recipient != address(this)) {
                 IERC20(tokenOut).safeTransfer(recipient, received);
@@ -372,13 +307,7 @@ contract PropAMMRouter is
         address recipient
     ) private returns (uint256 amountOut) {
         amountOut = UniV3Router.swapExactIn(
-            tokenIn,
-            tokenOut,
-            fallbackFee,
-            amountIn,
-            amountOutMin,
-            recipient,
-            fallbackSwapRouter
+            tokenIn, tokenOut, fallbackFee, amountIn, amountOutMin, recipient, fallbackSwapRouter
         );
         return amountOut;
     }
@@ -387,11 +316,10 @@ contract PropAMMRouter is
     /// @dev Delegates to `_pickBestVenue` (which compares the proprietary AMMs
     /// and the Uniswap V3 baseline) and reverts `NoQuotesAvailable` if nothing
     /// could be priced.
-    function quoteV1(
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) public returns (uint256 bestQuote, address venue) {
+    function quoteV1(address tokenIn, address tokenOut, uint256 amount)
+        public
+        returns (uint256 bestQuote, address venue)
+    {
         (bestQuote, venue) = _pickBestVenue(tokenIn, tokenOut, amount);
         require(bestQuote > 0, NoQuotesAvailable());
     }
@@ -402,33 +330,18 @@ contract PropAMMRouter is
     /// rather than the swap wrapper to save gas. Uniswap V3 is intentionally not
     /// quotable here — it is only surfaced through `quoteV1`. Reverts
     /// `UnknownVenue` for any non-whitelisted address.
-    function quoteVenueV1(
-        address venue,
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) public returns (uint256 amountOut) {
+    function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
+        public
+        returns (uint256 amountOut)
+    {
         if (venue == FERMI_ROUTER) {
             int256 amountInt256 = amount.toInt256();
-            (, amountOut) = IFermiSwapper(FERMI_ROUTER).quoteAmounts(
-                tokenIn,
-                tokenOut,
-                amountInt256
-            );
+            (, amountOut) = IFermiSwapper(FERMI_ROUTER).quoteAmounts(tokenIn, tokenOut, amountInt256);
         } else if (venue == KIPSELI_PAMM) {
-            amountOut = IKipseliQuoter(KIPSELI_QUOTER).preSwapQuote(
-                tokenIn,
-                amount,
-                tokenOut,
-                block.timestamp * 1000,
-                address(0)
-            );
+            amountOut = IKipseliQuoter(KIPSELI_QUOTER)
+                .preSwapQuote(tokenIn, amount, tokenOut, block.timestamp * 1000, address(0));
         } else if (venue == BEBOP_ROUTER) {
-            amountOut = IBebopRouter(BEBOP_ROUTER).quote(
-                tokenIn,
-                tokenOut,
-                amount
-            );
+            amountOut = IBebopRouter(BEBOP_ROUTER).quote(tokenIn, tokenOut, amount);
         } else {
             revert UnknownVenue();
         }
@@ -444,19 +357,8 @@ contract PropAMMRouter is
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return amountOut The amount of `tokenOut` the Uniswap V3 swap would produce.
-    function quoteUniswapV3(
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) external returns (uint256 amountOut) {
-        return
-            UniV3Router.quoteExactIn(
-                tokenIn,
-                tokenOut,
-                fallbackFee,
-                amount,
-                fallbackQuoter
-            );
+    function quoteUniswapV3(address tokenIn, address tokenOut, uint256 amount) external returns (uint256 amountOut) {
+        return UniV3Router.quoteExactIn(tokenIn, tokenOut, fallbackFee, amount, fallbackQuoter);
     }
 
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of
@@ -474,16 +376,13 @@ contract PropAMMRouter is
     /// @return bestQuote The best `tokenOut` amount found across all venues.
     /// @return venue The proprietary AMM that produced `bestQuote`, or
     /// `address(0)` if the Uniswap V3 baseline won (or nothing could be priced).
-    function _pickBestVenue(
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) internal returns (uint256 bestQuote, address venue) {
+    function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
+        internal
+        returns (uint256 bestQuote, address venue)
+    {
         address[3] memory venues = [FERMI_ROUTER, KIPSELI_PAMM, BEBOP_ROUTER];
         for (uint256 i = 0; i < venues.length; i++) {
-            try this.quoteVenueV1(venues[i], tokenIn, tokenOut, amount) returns (
-                uint256 amountOut
-            ) {
+            try this.quoteVenueV1(venues[i], tokenIn, tokenOut, amount) returns (uint256 amountOut) {
                 if (amountOut > bestQuote) {
                     bestQuote = amountOut;
                     venue = venues[i];
@@ -494,9 +393,7 @@ contract PropAMMRouter is
         // Uniswap V3 is a baseline candidate but not a nameable venue: when it
         // wins, `venue` stays `address(0)` so the result is never an address
         // that `swapViaVenueV1` / `quoteVenueV1` would reject.
-        try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (
-            uint256 amountOut
-        ) {
+        try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
                 venue = address(0);
@@ -510,10 +407,7 @@ contract PropAMMRouter is
     /// is deliberately excluded — it is reachable only via `swapV1`'s best-quote
     /// selection or as the failure fallback.
     function _isVenue(address venue) private pure returns (bool) {
-        return
-            venue == FERMI_ROUTER ||
-            venue == KIPSELI_PAMM ||
-            venue == BEBOP_ROUTER;
+        return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER;
     }
 
     /// @dev Restricts UUPS upgrades to the contract owner set in `initialize`.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -282,7 +282,7 @@ contract PropAMMRouter is
 
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         if (amountOut < amountOutMin) {
-            revert();
+            revert InsufficientOutput(amountOutMin, amountOut);
         }
 
         return amountOut;

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -104,15 +104,12 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Picks the best-quoting venue across the proprietary AMMs and the
-    /// Uniswap V3 baseline via `_pickBestVenue`, then executes it through
-    /// `_coreSwap`. If every venue fails to quote, `_pickBestVenue` yields
-    /// `address(0)` and `_coreSwap` routes straight to the Uniswap fallback.
-    /// Fails fast with `QuoteBelowMinimum` when even the best quote (which spans
-    /// the proprietary venues and the Uniswap fallback at `fallbackFee`) is
-    /// under `amountOutMin`, rejecting a doomed swap before pulling funds and
-    /// running the venue/fallback path. Quotes are advisory, so `_coreSwap`
-    /// still enforces `amountOutMin` against the delivered balance delta.
+    /// @dev Picks the best-quoting venue via `_pickBestVenue`, then executes
+    /// through `_coreSwap`; an `address(0)` selection (no venue could quote)
+    /// routes straight to the Uniswap fallback. Reverts `QuoteBelowMinimum`
+    /// before pulling funds when the best quote is under `amountOutMin`. Quotes
+    /// are advisory, so `_coreSwap` re-checks `amountOutMin` against the
+    /// delivered balance delta.
     function swapV1(
         address tokenIn,
         address tokenOut,

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -41,10 +41,15 @@ contract PropAMMRouter is
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
-    /// @notice Uniswap V3 SwapRouter02 used when the proprietary AMM swap reverts.
-    address fallbackSwapRouter;
+    /// @notice Uniswap V3 SwapRouter02 used when the proprietary AMM swap
+    /// reverts. Also the sentinel that identifies the Uniswap venue (see
+    /// `_isVenue`). Owner-settable via `setFallbackSwapRouter` so a new
+    /// SwapRouter deployment can be adopted without a contract upgrade.
+    address public fallbackSwapRouter;
     /// @notice Uniswap V3 QuoterV2 used to price the fallback route off-chain.
-    address fallbackQuoter;
+    /// Owner-settable via `setFallbackQuoter` so a new QuoterV2 deployment can
+    /// be adopted without a contract upgrade.
+    address public fallbackQuoter;
     /// @notice Uniswap V3 pool fee tier (in hundredths of a bip) used for the
     /// Uniswap fallback quote and swap. `3000` = 0.30% by default; the owner can
     /// retune it via `setFallbackFee` without a contract upgrade.
@@ -77,6 +82,34 @@ contract PropAMMRouter is
     error NoQuotesAvailable();
     /// @notice Thrown when `tokenOut` balance decreases after a swap.
     error TokenOutBalanceDecreased();
+    /// @notice Thrown when a Uniswap V3 fee tier is invalid: `0` (which resolves
+    /// to no pool and would brick the fallback) or at/above the factory's
+    /// `1_000_000` (100%) cap.
+    error InvalidFallbackFee(uint24 fee);
+    /// @notice Thrown when an address argument that must be non-zero is zero.
+    error ZeroAddress();
+
+    // `Swapped` is declared in IPropAMMRouter (part of the published interface)
+    // and inherited here. The operational events below are implementation
+    // detail and stay contract-local.
+
+    /// @notice Emitted when the owner retunes the Uniswap V3 fallback fee tier.
+    /// @param oldFee The previous `fallbackFee`.
+    /// @param newFee The new `fallbackFee`.
+    event FallbackFeeUpdated(uint24 oldFee, uint24 newFee);
+    /// @notice Emitted when the owner repoints the Uniswap V3 SwapRouter02.
+    /// @param oldRouter The previous `fallbackSwapRouter`.
+    /// @param newRouter The new `fallbackSwapRouter`.
+    event FallbackSwapRouterUpdated(address indexed oldRouter, address indexed newRouter);
+    /// @notice Emitted when the owner repoints the Uniswap V3 QuoterV2.
+    /// @param oldQuoter The previous `fallbackQuoter`.
+    /// @param newQuoter The new `fallbackQuoter`.
+    event FallbackQuoterUpdated(address indexed oldQuoter, address indexed newQuoter);
+    /// @notice Emitted when the owner rescues tokens stranded on the router.
+    /// @param token The ERC-20 rescued.
+    /// @param to The recipient of the rescued tokens.
+    /// @param amount The amount transferred.
+    event TokensRescued(address indexed token, address indexed to, uint256 amount);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -86,15 +119,19 @@ contract PropAMMRouter is
     /// @notice Initializes the router, pinning the Uniswap V3 fallback contracts
     /// and setting the owner who controls future upgrades.
     /// @param fallbackSwapRouter_ Address of the Uniswap V3 SwapRouter02 used
-    /// to execute the fallback swap.
+    /// to execute the fallback swap. Reverts `ZeroAddress` if zero — it also
+    /// doubles as the Uniswap venue sentinel, so a zero value would corrupt
+    /// venue identity (`_isVenue`, `_pickBestVenue`, `_coreSwap`).
     /// @param fallbackQuoter_ Address of the Uniswap V3 QuoterV2 used to quote
-    /// the fallback swap off-chain.
+    /// the fallback swap off-chain. Reverts `ZeroAddress` if zero.
     /// @param owner_ Initial owner of the proxy. Set directly here with no
     /// acceptance step — `Ownable2Step`'s two-step handoff only governs
     /// *subsequent* transfers via `transferOwnership` / `acceptOwnership`.
     /// Controls `_authorizeUpgrade` and any owner-gated administrative paths.
     /// Reverts if zero (enforced by `__Ownable_init`).
     function initialize(address fallbackSwapRouter_, address fallbackQuoter_, address owner_) public initializer {
+        require(fallbackSwapRouter_ != address(0), ZeroAddress());
+        require(fallbackQuoter_ != address(0), ZeroAddress());
         fallbackSwapRouter = fallbackSwapRouter_;
         fallbackQuoter = fallbackQuoter_;
         fallbackFee = 3000;
@@ -119,6 +156,9 @@ contract PropAMMRouter is
         address recipient,
         uint256 deadline
     ) external whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
+        // Fail fast before the on-chain best-venue quoting; `_coreSwap` re-checks
+        // for the shared path also reached by `swapViaVenueV1`.
+        require(block.timestamp <= deadline, Expired());
         (uint256 bestQuote, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
         require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
         return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
@@ -141,6 +181,40 @@ contract PropAMMRouter is
     ) public whenNotPaused nonReentrant returns (uint256 amountOut) {
         require(_isVenue(venue), UnknownVenue());
         (amountOut,) = _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+    }
+
+    /// @inheritdoc IPropAMMRouter
+    /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
+    /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with
+    /// `swapV1`, the Uniswap V3 fallback remains the transparent safety net
+    /// inside `_coreSwap` (a chosen proprietary venue recovers on Uniswap if it
+    /// fails to fill); it is not a selection candidate unless the caller lists
+    /// the `fallbackSwapRouter` address. Reverts `NoQuotesAvailable` if none of
+    /// `venues` can be priced, and `QuoteBelowMinimum` before pulling funds when
+    /// the best quote across `venues` is under `amountOutMin`; quotes are
+    /// advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
+    /// balance delta.
+    function swapViaSelectedVenuesV1(
+        address[] calldata venues,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline
+    ) public whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
+        // Fail fast before the on-chain requote; `_coreSwap` re-checks deadline.
+        require(block.timestamp <= deadline, Expired());
+        (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
+        // Reject when none of the selected venues could be priced (venue stays
+        // address(0)). Without this, an `amountOutMin == 0` call would slip past
+        // the QuoteBelowMinimum check and silently route to the Uniswap fallback
+        // the caller never selected. Mirrors `quoteSelectedVenuesV1`. A selected
+        // venue that quotes but then fails to fill still recovers on Uniswap
+        // inside `_coreSwap` — that transparent fallback is unaffected.
+        require(venue != address(0), NoQuotesAvailable());
+        require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
+        return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 
     /// @notice Pulls funds once and executes a swap, attempting `venue` first
@@ -188,6 +262,7 @@ contract PropAMMRouter is
             ) returns (
                 uint256 amountOut_
             ) {
+                _emitSwapped(venue, tokenIn, tokenOut, amountIn, amountOut_, recipient);
                 return (amountOut_, venue);
             } catch {
                 // Fall through to the Uniswap V3 fallback below.
@@ -197,7 +272,34 @@ contract PropAMMRouter is
         swapViaUniswapV3(tokenIn, tokenOut, amountIn, amountOutMin, recipient);
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         require(amountOut >= amountOutMin, InsufficientOutput(amountOutMin, amountOut));
+        _emitSwapped(fallbackSwapRouter, tokenIn, tokenOut, amountIn, amountOut, recipient);
         return (amountOut, fallbackSwapRouter);
+    }
+
+    /// @notice Logs a completed swap.
+    /// @dev Wraps the `Swapped` emit so `_coreSwap` does not carry the event's
+    /// arguments live on its (already param-heavy) stack at the emit site —
+    /// avoids a stack-too-deep without enabling `viaIR`. `msg.sender` is read
+    /// here and equals `_coreSwap`'s caller (and the entrypoint's), since
+    /// internal calls preserve the message context.
+    /// @param marketMaker The venue that filled, or `fallbackSwapRouter`. Placed
+    /// first (not in `Swapped`'s field order) so the deepest `_coreSwap` local
+    /// (`venue`) is read at the shallowest stack reach — another stack-too-deep
+    /// guard. The helper maps params to the event's field order internally.
+    /// @param tokenIn The token sold.
+    /// @param tokenOut The token bought.
+    /// @param amountIn The exact amount of `tokenIn` pulled from the caller.
+    /// @param amountOut The amount of `tokenOut` delivered to `recipient`.
+    /// @param recipient The address that received `tokenOut`.
+    function _emitSwapped(
+        address marketMaker,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOut,
+        address recipient
+    ) private {
+        emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient, marketMaker);
     }
 
     /// @notice Executes a swap on a proprietary venue with funds already held by
@@ -349,6 +451,21 @@ contract PropAMMRouter is
         }
     }
 
+    /// @inheritdoc IPropAMMRouter
+    /// @dev Delegates to `_pickBestVenueFrom`, considering ONLY `venues`, and
+    /// reverts `NoQuotesAvailable` if none of them can be priced. Venues that
+    /// revert while quoting — including non-whitelisted addresses, which
+    /// `quoteVenueV1` rejects with `UnknownVenue` — are skipped, not surfaced.
+    /// Not `view` (the Kipseli/Uniswap branches price via revert-based
+    /// simulation); call via `eth_call` (staticcall) off-chain.
+    function quoteSelectedVenuesV1(address[] calldata venues, address tokenIn, address tokenOut, uint256 amountIn)
+        public
+        returns (uint256 bestAmountOut, address bestVenue)
+    {
+        (bestAmountOut, bestVenue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
+        require(bestAmountOut > 0, NoQuotesAvailable());
+    }
+
     /// @notice Quotes the Uniswap V3 fallback for the pair at the current
     /// `fallbackFee` tier.
     /// @dev External so `_pickBestVenue` and `quoteV1` can wrap it in a
@@ -412,6 +529,37 @@ contract PropAMMRouter is
         } catch {}
     }
 
+    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
+    /// `tokenIn` among a caller-supplied set of venues.
+    /// @dev Quotes ONLY the provided `venues` (each via `this.quoteVenueV1` in
+    /// its own `try/catch`), so a venue that reverts — including a
+    /// non-whitelisted address, which `quoteVenueV1` rejects with `UnknownVenue`
+    /// — is simply skipped. Unlike `_pickBestVenue`, it does NOT seed or
+    /// auto-include the Uniswap fallback: the returned `venue` is `address(0)`
+    /// when none of the supplied venues can be priced. The Uniswap fallback
+    /// still applies at execution time via `_coreSwap` (the transparent safety
+    /// net); it is just not a selection candidate here unless the caller lists
+    /// the `fallbackSwapRouter` address explicitly.
+    /// @param venues The venues to consider — a subset the caller chose.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return bestQuote The best `tokenOut` amount found across `venues`, or 0.
+    /// @return venue The venue that produced `bestQuote`, or `address(0)` if none.
+    function _pickBestVenueFrom(address[] calldata venues, address tokenIn, address tokenOut, uint256 amount)
+        internal
+        returns (uint256 bestQuote, address venue)
+    {
+        for (uint256 i = 0; i < venues.length; i++) {
+            try this.quoteVenueV1(venues[i], tokenIn, tokenOut, amount) returns (uint256 amountOut) {
+                if (amountOut > bestQuote) {
+                    bestQuote = amountOut;
+                    venue = venues[i];
+                }
+            } catch {}
+        }
+    }
+
     /// @notice Returns whether `venue` is a venue a caller may name explicitly in
     /// `quoteVenueV1` / `swapViaVenueV1`.
     /// @dev The callable set is the three hardcoded proprietary routers plus the
@@ -419,7 +567,11 @@ contract PropAMMRouter is
     /// (SwapRouter02) address. `view` rather than `pure` because it reads that
     /// storage address. Internal "is this proprietary?" logic instead keys on
     /// `venue != fallbackSwapRouter` (see `_coreSwap`).
+    /// @dev `address(0)` is rejected explicitly: `initialize` already forbids a
+    /// zero `fallbackSwapRouter`, but this keeps "zero is never a venue" true at
+    /// the gate regardless of how storage was reached.
     function _isVenue(address venue) private view returns (bool) {
+        if (venue == address(0)) return false;
         return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER || venue == fallbackSwapRouter;
     }
 
@@ -432,7 +584,34 @@ contract PropAMMRouter is
     /// @param fee The Uniswap V3 fee tier in hundredths of a bip (e.g. `3000`
     /// for 0.30%).
     function setFallbackFee(uint24 fee) external onlyOwner {
+        require(fee != 0 && fee < 1_000_000, InvalidFallbackFee(fee));
+        emit FallbackFeeUpdated(fallbackFee, fee);
         fallbackFee = fee;
+    }
+
+    /// @notice Repoints the Uniswap V3 SwapRouter02 used by the fallback route.
+    /// @dev Owner-gated. Lets a new SwapRouter deployment be adopted without a
+    /// contract upgrade. Reverts `ZeroAddress` if zero — this address also
+    /// identifies the Uniswap venue (`_isVenue`, `_pickBestVenue`, `_coreSwap`),
+    /// so a zero value would corrupt venue identity. Note that `executedVenue`
+    /// values observed off-chain are only meaningful relative to the router's
+    /// configuration at the time of the swap.
+    /// @param newRouter Address of the new Uniswap V3 SwapRouter02.
+    function setFallbackSwapRouter(address newRouter) external onlyOwner {
+        require(newRouter != address(0), ZeroAddress());
+        emit FallbackSwapRouterUpdated(fallbackSwapRouter, newRouter);
+        fallbackSwapRouter = newRouter;
+    }
+
+    /// @notice Repoints the Uniswap V3 QuoterV2 used to price the fallback route.
+    /// @dev Owner-gated. Lets a new QuoterV2 deployment be adopted without a
+    /// contract upgrade. Reverts `ZeroAddress` if zero (a zero quoter would make
+    /// every Uniswap quote revert and be silently dropped from selection).
+    /// @param newQuoter Address of the new Uniswap V3 QuoterV2.
+    function setFallbackQuoter(address newQuoter) external onlyOwner {
+        require(newQuoter != address(0), ZeroAddress());
+        emit FallbackQuoterUpdated(fallbackQuoter, newQuoter);
+        fallbackQuoter = newQuoter;
     }
 
     /// @notice Pauses swaps, blocking new swaps until `unpause` is called.
@@ -444,5 +623,19 @@ contract PropAMMRouter is
     /// @notice Unpauses swaps.
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    /// @notice Rescues ERC-20 tokens stranded on the router.
+    /// @dev Owner-gated. The router holds no balance between swaps, so any
+    /// standing balance is unintended (mis-sent funds, fee-on-transfer dust, or
+    /// a partial-pull remainder). Not `nonReentrant`: it must stay callable and
+    /// it moves no in-flight swap funds — swaps are atomic and `nonReentrant`.
+    /// @param token The ERC-20 to rescue.
+    /// @param to The recipient of the rescued tokens.
+    /// @param amount The amount to transfer.
+    function rescueTokens(address token, address to, uint256 amount) external onlyOwner {
+        require(to != address(0), ZeroAddress());
+        IERC20(token).safeTransfer(to, amount);
+        emit TokensRescued(token, to, amount);
     }
 }

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -25,7 +25,7 @@ import {UniV3Router} from "./libraries/UniV3Router.sol";
 /// are identified by address: the venues a caller may name explicitly are the
 /// three proprietary AMMs plus Uniswap V3 (see `_isVenue`), the latter named by
 /// the `fallbackSwapRouter` (SwapRouter02) address. Uniswap V3 is also folded
-/// into `quoteV1` as a baseline price and is reached automatically (best-quote
+/// into `quoteV1` as a fallback candidate and is reached automatically (best-quote
 /// selection in `swapV1`, or as the failure fallback when a proprietary venue
 /// reverts). The Uniswap fee tier is the owner-settable `fallbackFee`, so
 /// callers never pass one. The owner authorized in `initialize` controls
@@ -47,8 +47,7 @@ contract PropAMMRouter is
     address fallbackQuoter;
     /// @notice Uniswap V3 pool fee tier (in hundredths of a bip) used for the
     /// Uniswap fallback quote and swap. `3000` = 0.30% by default; the owner can
-    /// retune it via `setFallbackFee` without a contract upgrade. Appended after
-    /// the existing storage variables to keep the UUPS layout upgrade-safe.
+    /// retune it via `setFallbackFee` without a contract upgrade.
     uint24 public fallbackFee;
 
     /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
@@ -107,8 +106,8 @@ contract PropAMMRouter is
     /// @inheritdoc IPropAMMRouter
     /// @dev Picks the best-quoting venue via `_pickBestVenue`, then executes
     /// through `_coreSwap`; a `fallbackSwapRouter` selection (the Uniswap
-    /// baseline won, or no venue could quote) routes straight to the Uniswap
-    /// fallback. Reverts `QuoteBelowMinimum`
+    /// fallback won, or no venue could quote) routes straight to Uniswap V3.
+    /// Reverts `QuoteBelowMinimum`
     /// before pulling funds when the best quote is under `amountOutMin`. Quotes
     /// are advisory, so `_coreSwap` re-checks `amountOutMin` against the
     /// delivered balance delta.
@@ -127,7 +126,7 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev `venue` must be a callable venue (`_isVenue`): one of the three
-    /// proprietary AMMs or the Uniswap V3 baseline, named by the
+    /// proprietary AMMs or the Uniswap V3 fallback, named by the
     /// `fallbackSwapRouter` address. Naming Uniswap runs it directly via
     /// `_coreSwap`'s `fallbackSwapRouter` path (no proprietary attempt); a
     /// proprietary `venue` still recovers on Uniswap if it fails to fill.
@@ -153,7 +152,7 @@ contract PropAMMRouter is
     /// for a proprietary `venue`, wraps the venue call in `try this._dispatchVenue`
     /// so a revert (including an under-fill, which `_dispatchVenue` turns into a
     /// revert) is caught and recovered on Uniswap V3; for `fallbackSwapRouter`
-    /// (no proprietary venue selected, or the Uniswap baseline was best) it runs
+    /// (no proprietary venue selected, or the Uniswap fallback was best) it runs
     /// Uniswap V3 directly. The external self-call is intentional: only an
     /// external call produces a catchable frame and rolls back the venue's
     /// `forceApprove`. The Uniswap branch re-measures the delivered delta and
@@ -282,7 +281,7 @@ contract PropAMMRouter is
 
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         if (amountOut < amountOutMin) {
-            revert();
+            revert InsufficientOutput(amountOutMin, amountOut);
         }
 
         return amountOut;
@@ -315,7 +314,7 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Delegates to `_pickBestVenue` (which compares the proprietary AMMs
-    /// and the Uniswap V3 baseline) and reverts `NoQuotesAvailable` if nothing
+    /// and the Uniswap V3 fallback) and reverts `NoQuotesAvailable` if nothing
     /// could be priced.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         public
@@ -327,7 +326,7 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Dispatches by address across the three proprietary AMMs plus the
-    /// Uniswap V3 baseline (named by the `fallbackSwapRouter` address). Kipseli is
+    /// Uniswap V3 fallback (named by the `fallbackSwapRouter` address). Kipseli is
     /// quoted via the dedicated `IKipseliQuoter.preSwapQuote` contract rather than
     /// the swap wrapper to save gas; Uniswap V3 is priced via QuoterV2 at the
     /// owner-set `fallbackFee` tier. Reverts `UnknownVenue` for any other address.
@@ -350,7 +349,7 @@ contract PropAMMRouter is
         }
     }
 
-    /// @notice Quotes the Uniswap V3 baseline for the pair at the current
+    /// @notice Quotes the Uniswap V3 fallback for the pair at the current
     /// `fallbackFee` tier.
     /// @dev External so `_pickBestVenue` and `quoteV1` can wrap it in a
     /// `try/catch` (an internal library call can't be caught). Not `view`:
@@ -365,7 +364,7 @@ contract PropAMMRouter is
     }
 
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of
-    /// `tokenIn` across the proprietary AMMs and the Uniswap V3 baseline.
+    /// `tokenIn` across the proprietary AMMs and the Uniswap V3 fallback.
     /// @dev Each venue is queried in its own `try/catch` so a reverting venue is
     /// simply skipped. Returns `(0, fallbackSwapRouter)` when nothing can be
     /// priced — callers that need a hard failure (e.g. `quoteV1`) check the
@@ -373,19 +372,19 @@ contract PropAMMRouter is
     /// `fallbackSwapRouter` case to Uniswap. The returned `venue` is one of the
     /// whitelisted proprietary AMMs or `fallbackSwapRouter`; the latter is a
     /// callable venue too (`swapViaVenueV1` / `quoteVenueV1` accept it) and is
-    /// also consumed by `_coreSwap` (via `swapV1`) as the Uniswap baseline.
+    /// also consumed by `_coreSwap` (via `swapV1`) as the Uniswap fallback.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount found across all venues.
     /// @return venue The venue that produced `bestQuote` — a proprietary AMM, or
-    /// `fallbackSwapRouter` if the Uniswap V3 baseline won (or nothing could be
+    /// `fallbackSwapRouter` if the Uniswap V3 fallback won (or nothing could be
     /// priced).
     function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
         internal
         returns (uint256 bestQuote, address venue)
     {
-        // Uniswap V3 is the always-present baseline, so seed the winner with
+        // Uniswap V3 is the always-present fallback, so seed the winner with
         // its SwapRouter02 address. A proprietary venue overtakes it only by
         // quoting strictly more; if none do (or nothing can be priced at all),
         // `venue` stays `fallbackSwapRouter` and `_coreSwap` routes to Uniswap.
@@ -401,9 +400,9 @@ contract PropAMMRouter is
             } catch {}
         }
 
-        // Uniswap V3 is the always-present baseline candidate: when it wins,
+        // Uniswap V3 is the always-present fallback candidate: when it wins,
         // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
-        // treats as the Uniswap baseline. Callers may also name that address
+        // treats as the Uniswap fallback. Callers may also name that address
         // directly through `swapViaVenueV1` / `quoteVenueV1`.
         try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
@@ -416,7 +415,7 @@ contract PropAMMRouter is
     /// @notice Returns whether `venue` is a venue a caller may name explicitly in
     /// `quoteVenueV1` / `swapViaVenueV1`.
     /// @dev The callable set is the three hardcoded proprietary routers plus the
-    /// Uniswap V3 baseline, identified by the live `fallbackSwapRouter`
+    /// Uniswap V3 fallback, identified by the live `fallbackSwapRouter`
     /// (SwapRouter02) address. `view` rather than `pure` because it reads that
     /// storage address. Internal "is this proprietary?" logic instead keys on
     /// `venue != fallbackSwapRouter` (see `_coreSwap`).

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -164,14 +164,14 @@ contract PropAMMRouter is
     /// from `msg.sender`, snapshots `recipient`'s `tokenOut` balance, then:
     /// for a proprietary `venue`, wraps the venue call in `try this._dispatchVenue`
     /// so a revert (including an under-fill, which `_dispatchVenue` turns into a
-    /// revert) is caught and recovered on Uniswap V3; for `fallbackSwapRouter`
-    /// or `address(0)` it runs Uniswap V3 directly, avoiding a pointless
-    /// Uniswap-to-Uniswap fallback. The external self-call is intentional: only
-    /// an external call produces a catchable frame and rolls back the venue's
+    /// revert) is caught and recovered on Uniswap V3; for `address(0)` (no
+    /// proprietary venue selected, or the Uniswap baseline was best) it runs
+    /// Uniswap V3 directly. The external self-call is intentional: only an
+    /// external call produces a catchable frame and rolls back the venue's
     /// `forceApprove`. The Uniswap branch re-measures the delivered delta and
     /// enforces `amountOutMin` to defend against an under-delivering router.
-    /// @param venue The venue to attempt first: a proprietary AMM, or
-    /// `fallbackSwapRouter`/`address(0)` to go straight to Uniswap V3.
+    /// @param venue The proprietary AMM to attempt first, or `address(0)` to go
+    /// straight to the Uniswap V3 fallback.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -179,8 +179,8 @@ contract PropAMMRouter is
     /// @param recipient The address that will receive `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` delivered to `recipient`.
-    /// @return executedVenue The venue that filled the swap; `fallbackSwapRouter`
-    /// when Uniswap V3 ran.
+    /// @return executedVenue The proprietary AMM that filled the swap, or
+    /// `address(0)` when the Uniswap V3 fallback ran.
     function _coreSwap(
         address venue,
         address tokenIn,
@@ -195,7 +195,7 @@ contract PropAMMRouter is
 
         uint256 prevTokenOutBalance = IERC20(tokenOut).balanceOf(recipient);
 
-        if (venue != address(0) && venue != fallbackSwapRouter) {
+        if (venue != address(0)) {
             try
                 this._dispatchVenue(
                     venue,
@@ -220,7 +220,7 @@ contract PropAMMRouter is
             amountOut >= amountOutMin,
             InsufficientOutput(amountOutMin, amountOut)
         );
-        return (amountOut, fallbackSwapRouter);
+        return (amountOut, address(0));
     }
 
     /// @notice Executes a swap on a proprietary venue with funds already held by
@@ -445,12 +445,15 @@ contract PropAMMRouter is
     /// simply skipped. Returns `(0, address(0))` when nothing can be priced —
     /// callers that need a hard failure (e.g. `quoteV1`) check for that;
     /// `swapV1` instead lets `_coreSwap` route the `address(0)` case to Uniswap.
+    /// Every non-zero `venue` returned here is one of the whitelisted
+    /// proprietary AMMs, so it is always accepted by `swapViaVenueV1` /
+    /// `quoteVenueV1`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount found across all venues.
-    /// @return venue The venue that produced `bestQuote`; `fallbackSwapRouter`
-    /// if the Uniswap V3 baseline won.
+    /// @return venue The proprietary AMM that produced `bestQuote`, or
+    /// `address(0)` if the Uniswap V3 baseline won (or nothing could be priced).
     function _pickBestVenue(
         address tokenIn,
         address tokenOut,
@@ -468,13 +471,15 @@ contract PropAMMRouter is
             } catch {}
         }
 
-        // Uniswap V3 is a baseline candidate, addressed by its SwapRouter.
+        // Uniswap V3 is a baseline candidate but not a nameable venue: when it
+        // wins, `venue` stays `address(0)` so the result is never an address
+        // that `swapViaVenueV1` / `quoteVenueV1` would reject.
         try this.quoteUniswapV3(tokenIn, tokenOut, amount) returns (
             uint256 amountOut
         ) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
-                venue = fallbackSwapRouter;
+                venue = address(0);
             }
         } catch {}
     }

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -8,9 +8,10 @@ pragma solidity ^0.8.35;
 /// @dev A venue is either a whitelisted proprietary AMM address or the
 /// public-venue baseline/fallback, denoted by the implementation's Uniswap V3
 /// SwapRouter02 address. The quote/swap functions may return that baseline
-/// address to signal the public venue; the per-venue functions accept only the
-/// whitelisted proprietary addresses and reject the baseline. Route a baseline
-/// result returned by `quoteV1` through `swapV1`, not `swapViaVenueV1`.
+/// address to signal the public venue; the per-venue functions accept it too —
+/// naming the baseline address routes directly to the public venue. A baseline
+/// result returned by `quoteV1` may therefore be passed to either `swapV1` or
+/// `swapViaVenueV1`.
 interface IPropAMMRouter {
     /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
     /// possible, routing through the best-quoting venue and falling back to the
@@ -36,12 +37,15 @@ interface IPropAMMRouter {
     ) external returns (uint256 amountOut, address executedVenue);
 
     /// @notice Swaps an exact `amountIn` of `tokenIn` through a caller-specified
-    /// proprietary venue, falling back to the public-venue baseline if it fails.
+    /// venue, falling back to the public-venue baseline if a proprietary venue
+    /// fails.
     /// @dev The caller must approve this contract for at least `amountIn` of
-    /// `tokenIn`. Reverts `UnknownVenue` if `venue` is not whitelisted, or
-    /// reverts if the output is below `amountOutMin`. `venue` must be a
-    /// whitelisted proprietary AMM; use `swapV1` to reach the baseline directly.
-    /// @param venue The proprietary venue to attempt first.
+    /// `tokenIn`. Reverts `UnknownVenue` if `venue` is neither a whitelisted
+    /// proprietary AMM nor the baseline address, or reverts if the output is
+    /// below `amountOutMin`. Naming the baseline address routes directly to the
+    /// public venue with no fallback (it is the fallback).
+    /// @param venue The venue to attempt first — a proprietary AMM, or the
+    /// baseline address to swap on the public venue directly.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -74,12 +78,13 @@ interface IPropAMMRouter {
         external
         returns (uint256 bestQuote, address venue);
 
-    /// @notice Quotes `amount` of `tokenIn` against a single whitelisted
-    /// proprietary venue.
+    /// @notice Quotes `amount` of `tokenIn` against a single venue — a whitelisted
+    /// proprietary AMM or the public-venue baseline.
     /// @dev Not `view`; call via `eth_call` (staticcall) off-chain. Reverts
-    /// `UnknownVenue` if `venue` is not whitelisted, and bubbles up any revert
-    /// from the underlying venue.
-    /// @param venue The proprietary venue to quote against.
+    /// `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the
+    /// baseline address, and bubbles up any revert from the underlying venue.
+    /// @param venue The venue to quote against — a proprietary AMM, or the
+    /// baseline address for the public venue.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
     /// @param amount The amount of `tokenIn` to quote.

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -3,23 +3,14 @@ pragma solidity ^0.8.35;
 
 /// @title IPropAMMRouter
 /// @notice Router for single-hop swaps across whitelisted proprietary venues,
-/// with a public-venue fallback used when the chosen proprietary venue cannot
-/// fill.
-/// @dev A venue is either a whitelisted proprietary AMM address or the
-/// public-venue fallback, denoted by the implementation's Uniswap V3
-/// SwapRouter02 address. The quote/swap functions may return that fallback
-/// address to signal the public venue; the per-venue functions accept it too —
-/// naming the fallback address routes directly to the public venue. A fallback
-/// result returned by `quoteV1` may therefore be passed to either `swapV1` or
-/// `swapViaVenueV1`.
+/// with a public-venue fallback used when the chosen propAMM cannot fill.
+/// @dev A venue is either a whitelisted propAMM address or the public-venue fallback.
 interface IPropAMMRouter {
-    /// @notice Emitted once per successful swap — via `swapV1`, `swapViaVenueV1`,
-    /// `swapViaSelectedVenuesV1`, or any future swap entrypoint — after
-    /// `tokenOut` is delivered to `recipient` and the `amountOutMin` invariant
-    /// has been enforced.
+    /// @notice Emitted once per successful swap (via `swapV1`, `swapViaVenueV1`,
+    /// `swapViaSelectedVenuesV1`) after `tokenOut` is delivered to `recipient`.
     /// @param sender The address that invoked the swap entrypoint and supplied
-    /// `amountIn` of `tokenIn`. Indexed so consumers (e.g. a frontend) can fetch
-    /// a given account's recent swaps.
+    /// `amountIn` of `tokenIn`. Indexed so consumers can fetch a given account's
+    /// recent swaps.
     /// @param tokenIn The token sold.
     /// @param tokenOut The token bought.
     /// @param amountIn The exact amount of `tokenIn` pulled from `sender`.
@@ -27,7 +18,7 @@ interface IPropAMMRouter {
     /// measured as a balance delta.
     /// @param recipient The address that received `tokenOut`.
     /// @param marketMaker The proprietary AMM that filled, or the public-venue
-    /// fallback (Uniswap V3 SwapRouter02) when the fallback ran.
+    /// fallback address.
     event Swapped(
         address indexed sender,
         address indexed tokenIn,
@@ -40,7 +31,7 @@ interface IPropAMMRouter {
 
     /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
     /// possible, routing through the best-quoting venue and falling back to the
-    /// public-venue fallback if the chosen proprietary venue fails to fill.
+    /// public-venue fallback if the chosen venue fails to fill.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts if the output is below `amountOutMin`.
     /// @param tokenIn The token being sold.
@@ -50,8 +41,7 @@ interface IPropAMMRouter {
     /// @param recipient The address that receives `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` received by `recipient`.
-    /// @return executedVenue The proprietary venue that filled the swap, or the
-    /// Uniswap V3 SwapRouter02 address when the fallback ran.
+    /// @return executedVenue The venue that filled the swap, or the fallback venue address.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -62,15 +52,13 @@ interface IPropAMMRouter {
     ) external returns (uint256 amountOut, address executedVenue);
 
     /// @notice Swaps an exact `amountIn` of `tokenIn` through a caller-specified
-    /// venue, falling back to the public venue if a proprietary venue
-    /// fails.
+    /// venue, falling back to the public venue if it fails.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts `UnknownVenue` if `venue` is neither a whitelisted
-    /// proprietary AMM nor the fallback address, or reverts if the output is
+    /// propAMM nor the fallback address, or reverts if the output is
     /// below `amountOutMin`. Naming the fallback address routes directly to the
     /// public venue with no further fallback (it is the fallback).
-    /// @param venue The venue to attempt first — a proprietary AMM, or the
-    /// fallback address to swap on the public venue directly.
+    /// @param venue The venue address.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -128,18 +116,17 @@ interface IPropAMMRouter {
     /// @param tokenOut The token being bought.
     /// @param amount The amount of `tokenIn` to quote.
     /// @return bestQuote The best `tokenOut` amount across all venues.
-    /// @return venue The proprietary venue that produced `bestQuote`, or the
-    /// Uniswap V3 SwapRouter02 address if the fallback won.
+    /// @return venue The proprietary venue that produced `bestQuote`, or 
+    /// the fallback venue address if the fallback won.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         external
         returns (uint256 bestQuote, address venue);
 
     /// @notice Quotes `amount` of `tokenIn` against a single venue — a whitelisted
-    /// proprietary AMM or the public-venue fallback.
-    /// @dev Not `view`; call via `eth_call` (staticcall) off-chain. Reverts
-    /// `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the
+    /// propAMM or the public-venue fallback.
+    /// @dev Reverts `UnknownVenue` if `venue` is neither a whitelisted propAMM nor the
     /// fallback address, and bubbles up any revert from the underlying venue.
-    /// @param venue The venue to quote against — a proprietary AMM, or the
+    /// @param venue The venue to quote against — a propAMM address, or the
     /// fallback address for the public venue.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
@@ -153,8 +140,7 @@ interface IPropAMMRouter {
     /// venues and returns the best output and the venue that produced it.
     /// @dev Considers ONLY `venues` (not all available venues). Venues that
     /// revert while quoting — including non-whitelisted addresses — are skipped.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced. Not `view`;
-    /// call via `eth_call` (staticcall) off-chain.
+    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced.
     /// @param venues The venues to consider — a subset of the available venues.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -91,11 +91,9 @@ interface IPropAMMRouter {
     /// or `address(0)` if the Uniswap V3 baseline won. A non-zero result is
     /// always accepted by `swapViaVenueV1`; on `address(0)`, execute via
     /// `swapV1` to reach the Uniswap fallback.
-    function quoteV1(
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) external returns (uint256 bestQuote, address venue);
+    function quoteV1(address tokenIn, address tokenOut, uint256 amount)
+        external
+        returns (uint256 bestQuote, address venue);
 
     /// @notice Quotes `amount` of `tokenIn` against a single whitelisted
     /// proprietary venue.
@@ -109,10 +107,7 @@ interface IPropAMMRouter {
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return amountOut The amount of `tokenOut` quoted by `venue`.
-    function quoteVenueV1(
-        address venue,
-        address tokenIn,
-        address tokenOut,
-        uint256 amount
-    ) external returns (uint256 amountOut);
+    function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
+        external
+        returns (uint256 amountOut);
 }

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -13,6 +13,15 @@ pragma solidity ^0.8.35;
 /// automatically (best-quote selection in `swapV1`, or as the failure fallback).
 /// The Uniswap fallback fee tier is selected internally by the implementation,
 /// so callers never pass one.
+///
+/// Venue address space: a venue is one of the whitelisted proprietary AMM
+/// addresses, or `address(0)`, which denotes the Uniswap V3 baseline/fallback
+/// and is never a nameable venue. `quoteV1` / `swapV1` may return `address(0)`
+/// to signal the Uniswap baseline; `quoteVenueV1` / `swapViaVenueV1` accept
+/// only the non-zero whitelisted addresses. The invariant is that any non-zero
+/// venue returned by `quoteV1` is always accepted by the per-venue functions,
+/// so callers routing a `quoteV1` result need only special-case `address(0)`
+/// (by calling `swapV1`, which reaches the Uniswap fallback automatically).
 interface IPropAMMRouter {
     /// @notice Swaps an exact amount of `tokenIn` for as much `tokenOut` as
     /// possible, routing through whichever venue quotes best and falling back
@@ -29,8 +38,8 @@ interface IPropAMMRouter {
     /// @param recipient The address that will receive `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` actually received by `recipient`.
-    /// @return executedVenue The address of the venue that filled the swap; the
-    /// Uniswap V3 SwapRouter address when the fallback ran.
+    /// @return executedVenue The whitelisted proprietary AMM that filled the
+    /// swap, or `address(0)` when the Uniswap V3 fallback ran.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -46,7 +55,9 @@ interface IPropAMMRouter {
     /// cannot be named here and is only reached as the fallback. The caller
     /// must have approved this contract to spend at least `amountIn` of
     /// `tokenIn`. Reverts `UnknownVenue` if `venue` is not whitelisted, or
-    /// reverts if the final output is below `amountOutMin`.
+    /// reverts if the final output is below `amountOutMin`. Pass a non-zero
+    /// venue from `quoteV1`; its `address(0)` result is not accepted here (use
+    /// `swapV1` for that case).
     /// @param venue The proprietary venue to attempt the swap on first.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
@@ -76,8 +87,10 @@ interface IPropAMMRouter {
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return bestQuote The best `tokenOut` amount across all venues.
-    /// @return venue The venue that produced `bestQuote`; the Uniswap V3
-    /// SwapRouter address if the Uniswap baseline won.
+    /// @return venue The whitelisted proprietary AMM that produced `bestQuote`,
+    /// or `address(0)` if the Uniswap V3 baseline won. A non-zero result is
+    /// always accepted by `swapViaVenueV1`; on `address(0)`, execute via
+    /// `swapV1` to reach the Uniswap fallback.
     function quoteV1(
         address tokenIn,
         address tokenOut,

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -5,12 +5,12 @@ pragma solidity ^0.8.35;
 /// @notice Router for single-hop swaps across whitelisted proprietary venues,
 /// with a public-venue baseline that also serves as the fallback when the
 /// chosen proprietary venue cannot fill.
-/// @dev A venue is either a whitelisted proprietary AMM address or `address(0)`,
-/// which denotes the public-venue baseline/fallback. The quote/swap functions
-/// may return `address(0)` to signal the baseline; the per-venue functions
-/// accept only non-zero whitelisted addresses. Any non-zero venue returned by
-/// `quoteV1` is accepted by `swapViaVenueV1`; route an `address(0)` result
-/// through `swapV1` instead.
+/// @dev A venue is either a whitelisted proprietary AMM address or the
+/// public-venue baseline/fallback, denoted by the implementation's Uniswap V3
+/// SwapRouter02 address. The quote/swap functions may return that baseline
+/// address to signal the public venue; the per-venue functions accept only the
+/// whitelisted proprietary addresses and reject the baseline. Route a baseline
+/// result returned by `quoteV1` through `swapV1`, not `swapViaVenueV1`.
 interface IPropAMMRouter {
     /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
     /// possible, routing through the best-quoting venue and falling back to the
@@ -24,8 +24,8 @@ interface IPropAMMRouter {
     /// @param recipient The address that receives `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` received by `recipient`.
-    /// @return executedVenue The proprietary venue that filled the swap, or
-    /// `address(0)` when the baseline fallback ran.
+    /// @return executedVenue The proprietary venue that filled the swap, or the
+    /// Uniswap V3 SwapRouter02 address when the baseline fallback ran.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -39,8 +39,8 @@ interface IPropAMMRouter {
     /// proprietary venue, falling back to the public-venue baseline if it fails.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts `UnknownVenue` if `venue` is not whitelisted, or
-    /// reverts if the output is below `amountOutMin`. `venue` must be non-zero;
-    /// use `swapV1` to reach the baseline directly.
+    /// reverts if the output is below `amountOutMin`. `venue` must be a
+    /// whitelisted proprietary AMM; use `swapV1` to reach the baseline directly.
     /// @param venue The proprietary venue to attempt first.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
@@ -68,8 +68,8 @@ interface IPropAMMRouter {
     /// @param tokenOut The token being bought.
     /// @param amount The amount of `tokenIn` to quote.
     /// @return bestQuote The best `tokenOut` amount across all venues.
-    /// @return venue The proprietary venue that produced `bestQuote`, or
-    /// `address(0)` if the baseline won.
+    /// @return venue The proprietary venue that produced `bestQuote`, or the
+    /// Uniswap V3 SwapRouter02 address if the baseline won.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         external
         returns (uint256 bestQuote, address venue);

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -3,19 +3,19 @@ pragma solidity ^0.8.35;
 
 /// @title IPropAMMRouter
 /// @notice Router for single-hop swaps across whitelisted proprietary venues,
-/// with a public-venue baseline that also serves as the fallback when the
-/// chosen proprietary venue cannot fill.
+/// with a public-venue fallback used when the chosen proprietary venue cannot
+/// fill.
 /// @dev A venue is either a whitelisted proprietary AMM address or the
-/// public-venue baseline/fallback, denoted by the implementation's Uniswap V3
-/// SwapRouter02 address. The quote/swap functions may return that baseline
+/// public-venue fallback, denoted by the implementation's Uniswap V3
+/// SwapRouter02 address. The quote/swap functions may return that fallback
 /// address to signal the public venue; the per-venue functions accept it too —
-/// naming the baseline address routes directly to the public venue. A baseline
+/// naming the fallback address routes directly to the public venue. A fallback
 /// result returned by `quoteV1` may therefore be passed to either `swapV1` or
 /// `swapViaVenueV1`.
 interface IPropAMMRouter {
     /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
     /// possible, routing through the best-quoting venue and falling back to the
-    /// public-venue baseline if the chosen proprietary venue fails to fill.
+    /// public-venue fallback if the chosen proprietary venue fails to fill.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts if the output is below `amountOutMin`.
     /// @param tokenIn The token being sold.
@@ -26,7 +26,7 @@ interface IPropAMMRouter {
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` received by `recipient`.
     /// @return executedVenue The proprietary venue that filled the swap, or the
-    /// Uniswap V3 SwapRouter02 address when the baseline fallback ran.
+    /// Uniswap V3 SwapRouter02 address when the fallback ran.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -37,15 +37,15 @@ interface IPropAMMRouter {
     ) external returns (uint256 amountOut, address executedVenue);
 
     /// @notice Swaps an exact `amountIn` of `tokenIn` through a caller-specified
-    /// venue, falling back to the public-venue baseline if a proprietary venue
+    /// venue, falling back to the public venue if a proprietary venue
     /// fails.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts `UnknownVenue` if `venue` is neither a whitelisted
-    /// proprietary AMM nor the baseline address, or reverts if the output is
-    /// below `amountOutMin`. Naming the baseline address routes directly to the
-    /// public venue with no fallback (it is the fallback).
+    /// proprietary AMM nor the fallback address, or reverts if the output is
+    /// below `amountOutMin`. Naming the fallback address routes directly to the
+    /// public venue with no further fallback (it is the fallback).
     /// @param venue The venue to attempt first — a proprietary AMM, or the
-    /// baseline address to swap on the public venue directly.
+    /// fallback address to swap on the public venue directly.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
@@ -73,18 +73,18 @@ interface IPropAMMRouter {
     /// @param amount The amount of `tokenIn` to quote.
     /// @return bestQuote The best `tokenOut` amount across all venues.
     /// @return venue The proprietary venue that produced `bestQuote`, or the
-    /// Uniswap V3 SwapRouter02 address if the baseline won.
+    /// Uniswap V3 SwapRouter02 address if the fallback won.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         external
         returns (uint256 bestQuote, address venue);
 
     /// @notice Quotes `amount` of `tokenIn` against a single venue — a whitelisted
-    /// proprietary AMM or the public-venue baseline.
+    /// proprietary AMM or the public-venue fallback.
     /// @dev Not `view`; call via `eth_call` (staticcall) off-chain. Reverts
     /// `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the
-    /// baseline address, and bubbles up any revert from the underlying venue.
+    /// fallback address, and bubbles up any revert from the underlying venue.
     /// @param venue The venue to quote against — a proprietary AMM, or the
-    /// baseline address for the public venue.
+    /// fallback address for the public venue.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.
     /// @param amount The amount of `tokenIn` to quote.

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -2,44 +2,30 @@
 pragma solidity ^0.8.35;
 
 /// @title IPropAMMRouter
-/// @notice Interface for a router that executes single-hop swaps against a
-/// proprietary AMM (FermiSwap, Kipseli, or Bebop) or a public-venue fallback
-/// (Uniswap V3), with the public venue also serving as the recovery path when
-/// the chosen proprietary AMM cannot fill the swap.
-/// @dev Venues are identified by address rather than an enum. The set of
-/// proprietary venues a caller may name explicitly is the implementation's
-/// whitelist (FermiSwap, Kipseli, Bebop). Uniswap V3 is never named directly:
-/// it is folded into `quoteV1` as a baseline price and is only ever reached
-/// automatically (best-quote selection in `swapV1`, or as the failure fallback).
-/// The Uniswap fallback fee tier is selected internally by the implementation,
-/// so callers never pass one.
-///
-/// Venue address space: a venue is one of the whitelisted proprietary AMM
-/// addresses, or `address(0)`, which denotes the Uniswap V3 baseline/fallback
-/// and is never a nameable venue. `quoteV1` / `swapV1` may return `address(0)`
-/// to signal the Uniswap baseline; `quoteVenueV1` / `swapViaVenueV1` accept
-/// only the non-zero whitelisted addresses. The invariant is that any non-zero
-/// venue returned by `quoteV1` is always accepted by the per-venue functions,
-/// so callers routing a `quoteV1` result need only special-case `address(0)`
-/// (by calling `swapV1`, which reaches the Uniswap fallback automatically).
+/// @notice Router for single-hop swaps across whitelisted proprietary venues,
+/// with a public-venue baseline that also serves as the fallback when the
+/// chosen proprietary venue cannot fill.
+/// @dev A venue is either a whitelisted proprietary AMM address or `address(0)`,
+/// which denotes the public-venue baseline/fallback. The quote/swap functions
+/// may return `address(0)` to signal the baseline; the per-venue functions
+/// accept only non-zero whitelisted addresses. Any non-zero venue returned by
+/// `quoteV1` is accepted by `swapViaVenueV1`; route an `address(0)` result
+/// through `swapV1` instead.
 interface IPropAMMRouter {
-    /// @notice Swaps an exact amount of `tokenIn` for as much `tokenOut` as
-    /// possible, routing through whichever venue quotes best and falling back
-    /// to Uniswap V3 if the chosen proprietary venue fails to fill.
-    /// @dev The caller must have approved this contract to spend at least
-    /// `amountIn` of `tokenIn`. Reverts if the final output is below
-    /// `amountOutMin`. The executing venue is chosen internally by comparing
-    /// quotes across the proprietary venues and Uniswap V3.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
+    /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
+    /// possible, routing through the best-quoting venue and falling back to the
+    /// public-venue baseline if the chosen proprietary venue fails to fill.
+    /// @dev The caller must approve this contract for at least `amountIn` of
+    /// `tokenIn`. Reverts if the output is below `amountOutMin`.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
-    /// @param amountOutMin The minimum acceptable amount of `tokenOut`; the
-    /// swap reverts if the actual output is lower.
-    /// @param recipient The address that will receive `tokenOut`.
+    /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
+    /// @param recipient The address that receives `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
-    /// @return amountOut The amount of `tokenOut` actually received by `recipient`.
-    /// @return executedVenue The whitelisted proprietary AMM that filled the
-    /// swap, or `address(0)` when the Uniswap V3 fallback ran.
+    /// @return amountOut The amount of `tokenOut` received by `recipient`.
+    /// @return executedVenue The proprietary venue that filled the swap, or
+    /// `address(0)` when the baseline fallback ran.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -49,23 +35,20 @@ interface IPropAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountOut, address executedVenue);
 
-    /// @notice Swaps an exact amount of `tokenIn` through a caller-specified
-    /// proprietary venue, falling back to Uniswap V3 if that venue fails.
-    /// @dev `venue` must be one of the whitelisted proprietary AMMs; Uniswap V3
-    /// cannot be named here and is only reached as the fallback. The caller
-    /// must have approved this contract to spend at least `amountIn` of
+    /// @notice Swaps an exact `amountIn` of `tokenIn` through a caller-specified
+    /// proprietary venue, falling back to the public-venue baseline if it fails.
+    /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Reverts `UnknownVenue` if `venue` is not whitelisted, or
-    /// reverts if the final output is below `amountOutMin`. Pass a non-zero
-    /// venue from `quoteV1`; its `address(0)` result is not accepted here (use
-    /// `swapV1` for that case).
-    /// @param venue The proprietary venue to attempt the swap on first.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
+    /// reverts if the output is below `amountOutMin`. `venue` must be non-zero;
+    /// use `swapV1` to reach the baseline directly.
+    /// @param venue The proprietary venue to attempt first.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
     /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
-    /// @param recipient The address that will receive `tokenOut`.
+    /// @param recipient The address that receives `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
-    /// @return amountOut The amount of `tokenOut` actually received by `recipient`.
+    /// @return amountOut The amount of `tokenOut` received by `recipient`.
     function swapViaVenueV1(
         address venue,
         address tokenIn,
@@ -76,36 +59,30 @@ interface IPropAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountOut);
 
-    /// @notice Quotes `amount` of `tokenIn` against every venue (the
-    /// proprietary AMMs and the Uniswap V3 baseline) and returns the best
-    /// output along with the venue that produced it.
-    /// @dev Venues that revert when quoting are skipped. Reverts
-    /// `NoQuotesAvailable` if no venue can produce a quote. Not `view`: the
-    /// Uniswap V3 QuoterV2 branch prices via revert-based simulation. Call this
-    /// via `eth_call` (staticcall) from off-chain.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
-    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @notice Quotes `amount` of `tokenIn` across every venue and returns the
+    /// best output and the venue that produced it.
+    /// @dev Venues that revert while quoting are skipped. Reverts
+    /// `NoQuotesAvailable` if no venue can quote. Not `view`; call via
+    /// `eth_call` (staticcall) off-chain.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amount The amount of `tokenIn` to quote.
     /// @return bestQuote The best `tokenOut` amount across all venues.
-    /// @return venue The whitelisted proprietary AMM that produced `bestQuote`,
-    /// or `address(0)` if the Uniswap V3 baseline won. A non-zero result is
-    /// always accepted by `swapViaVenueV1`; on `address(0)`, execute via
-    /// `swapV1` to reach the Uniswap fallback.
+    /// @return venue The proprietary venue that produced `bestQuote`, or
+    /// `address(0)` if the baseline won.
     function quoteV1(address tokenIn, address tokenOut, uint256 amount)
         external
         returns (uint256 bestQuote, address venue);
 
     /// @notice Quotes `amount` of `tokenIn` against a single whitelisted
     /// proprietary venue.
-    /// @dev Not `view`: a venue's quote source may price via revert-based
-    /// simulation. Call this via `eth_call` (staticcall) from off-chain.
-    /// Reverts `UnknownVenue` if `venue` is not a whitelisted proprietary AMM.
-    /// Bubbles up any revert from the underlying venue (e.g. unsupported pair,
-    /// no liquidity, stale Kipseli oracle).
+    /// @dev Not `view`; call via `eth_call` (staticcall) off-chain. Reverts
+    /// `UnknownVenue` if `venue` is not whitelisted, and bubbles up any revert
+    /// from the underlying venue.
     /// @param venue The proprietary venue to quote against.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
-    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amount The amount of `tokenIn` to quote.
     /// @return amountOut The amount of `tokenOut` quoted by `venue`.
     function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
         external

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -13,6 +13,31 @@ pragma solidity ^0.8.35;
 /// result returned by `quoteV1` may therefore be passed to either `swapV1` or
 /// `swapViaVenueV1`.
 interface IPropAMMRouter {
+    /// @notice Emitted once per successful swap — via `swapV1`, `swapViaVenueV1`,
+    /// `swapViaSelectedVenuesV1`, or any future swap entrypoint — after
+    /// `tokenOut` is delivered to `recipient` and the `amountOutMin` invariant
+    /// has been enforced.
+    /// @param sender The address that invoked the swap entrypoint and supplied
+    /// `amountIn` of `tokenIn`. Indexed so consumers (e.g. a frontend) can fetch
+    /// a given account's recent swaps.
+    /// @param tokenIn The token sold.
+    /// @param tokenOut The token bought.
+    /// @param amountIn The exact amount of `tokenIn` pulled from `sender`.
+    /// @param amountOut The amount of `tokenOut` delivered to `recipient`,
+    /// measured as a balance delta.
+    /// @param recipient The address that received `tokenOut`.
+    /// @param marketMaker The proprietary AMM that filled, or the public-venue
+    /// fallback (Uniswap V3 SwapRouter02) when the fallback ran.
+    event Swapped(
+        address indexed sender,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        uint256 amountIn,
+        uint256 amountOut,
+        address recipient,
+        address marketMaker
+    );
+
     /// @notice Swaps an exact `amountIn` of `tokenIn` for as much `tokenOut` as
     /// possible, routing through the best-quoting venue and falling back to the
     /// public-venue fallback if the chosen proprietary venue fails to fill.
@@ -63,6 +88,37 @@ interface IPropAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountOut);
 
+    /// @notice Swaps an exact `amountIn` of `tokenIn` routing through the
+    /// best-quoting venue among a caller-selected set, instead of all available
+    /// venues. An on-chain requote across `venues` selects the best.
+    /// @dev The caller must approve this contract for at least `amountIn` of
+    /// `tokenIn`. Venues that revert while quoting (including non-whitelisted
+    /// addresses) are skipped. The public-venue fallback still applies as the
+    /// transparent safety net if the chosen proprietary venue fails to fill.
+    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and
+    /// `QuoteBelowMinimum` before pulling funds if the best quote across `venues`
+    /// is below `amountOutMin`, and re-checks `amountOutMin` against the
+    /// delivered balance delta after execution.
+    /// @param venues The venues to consider — a subset of the available venues.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
+    /// @param recipient The address that receives `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @return amountOut The amount of `tokenOut` received by `recipient`.
+    /// @return executedVenue The venue that filled the swap, or the public-venue
+    /// fallback address when the fallback ran.
+    function swapViaSelectedVenuesV1(
+        address[] calldata venues,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline
+    ) external returns (uint256 amountOut, address executedVenue);
+
     /// @notice Quotes `amount` of `tokenIn` across every venue and returns the
     /// best output and the venue that produced it.
     /// @dev Venues that revert while quoting are skipped. Reverts
@@ -92,4 +148,20 @@ interface IPropAMMRouter {
     function quoteVenueV1(address venue, address tokenIn, address tokenOut, uint256 amount)
         external
         returns (uint256 amountOut);
+
+    /// @notice Quotes `amountIn` of `tokenIn` across a caller-selected set of
+    /// venues and returns the best output and the venue that produced it.
+    /// @dev Considers ONLY `venues` (not all available venues). Venues that
+    /// revert while quoting — including non-whitelisted addresses — are skipped.
+    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced. Not `view`;
+    /// call via `eth_call` (staticcall) off-chain.
+    /// @param venues The venues to consider — a subset of the available venues.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amountIn The amount of `tokenIn` to quote.
+    /// @return bestAmountOut The best `tokenOut` amount across `venues`.
+    /// @return bestVenue The venue that produced `bestAmountOut`.
+    function quoteSelectedVenuesV1(address[] calldata venues, address tokenIn, address tokenOut, uint256 amountIn)
+        external
+        returns (uint256 bestAmountOut, address bestVenue);
 }

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -6,121 +6,98 @@ pragma solidity ^0.8.35;
 /// proprietary AMM (FermiSwap, Kipseli, or Bebop) or a public-venue fallback
 /// (Uniswap V3), with the public venue also serving as the recovery path when
 /// the chosen proprietary AMM cannot fill the swap.
+/// @dev Venues are identified by address rather than an enum. The set of
+/// proprietary venues a caller may name explicitly is the implementation's
+/// whitelist (FermiSwap, Kipseli, Bebop). Uniswap V3 is never named directly:
+/// it is folded into `quoteV1` as a baseline price and is only ever reached
+/// automatically (best-quote selection in `swapV1`, or as the failure fallback).
+/// The Uniswap fallback fee tier is selected internally by the implementation,
+/// so callers never pass one.
 interface IPropAMMRouter {
-    /// @notice Identifies which venue the caller wants to route through.
-    /// @dev `Fallback` selects the public venue (Uniswap V3) directly,
-    /// bypassing the proprietary AMMs. For the proprietary entries the
-    /// implementation is still free to fall back to Uniswap V3 if the
-    /// selected venue cannot fulfill the swap.
-    enum Venue {
-        Fallback,
-        FermiSwap,
-        Kipseli,
-        Bebop
-    }
-
-    /// @notice Swaps an exact amount of `tokenIn` for as much `tokenOut` as possible,
-    /// routing first through the selected venue and falling back to the public
-    /// venue if that route fails.
-    /// @dev The caller must have approved this contract to spend at least `amountIn`
-    /// of `tokenIn`. Reverts if the final output is below `amountOutMin`.
-    /// @param venue The venue to attempt the swap on first; pass `Venue.Fallback`
-    /// to skip the proprietary AMMs and go straight to Uniswap V3.
+    /// @notice Swaps an exact amount of `tokenIn` for as much `tokenOut` as
+    /// possible, routing through whichever venue quotes best and falling back
+    /// to Uniswap V3 if the chosen proprietary venue fails to fill.
+    /// @dev The caller must have approved this contract to spend at least
+    /// `amountIn` of `tokenIn`. Reverts if the final output is below
+    /// `amountOutMin`. The executing venue is chosen internally by comparing
+    /// quotes across the proprietary venues and Uniswap V3.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amountIn The exact amount of `tokenIn` to sell.
-    /// @param amountOutMin The minimum acceptable amount of `tokenOut`; the swap
-    /// reverts if the actual output is lower.
+    /// @param amountOutMin The minimum acceptable amount of `tokenOut`; the
+    /// swap reverts if the actual output is lower.
     /// @param recipient The address that will receive `tokenOut`.
-    /// @param uniswapFee The Uniswap V3 pool fee tier (in hundredths of a bip) used by
-    /// the fallback route; ignored by the proprietary AMM path.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountOut The amount of `tokenOut` actually received by `recipient`.
-    function swap(
-        Venue venue,
+    /// @return executedVenue The address of the venue that filled the swap; the
+    /// Uniswap V3 SwapRouter address when the fallback ran.
+    function swapV1(
         address tokenIn,
         address tokenOut,
         uint256 amountIn,
         uint256 amountOutMin,
         address recipient,
-        uint24 uniswapFee,
+        uint256 deadline
+    ) external returns (uint256 amountOut, address executedVenue);
+
+    /// @notice Swaps an exact amount of `tokenIn` through a caller-specified
+    /// proprietary venue, falling back to Uniswap V3 if that venue fails.
+    /// @dev `venue` must be one of the whitelisted proprietary AMMs; Uniswap V3
+    /// cannot be named here and is only reached as the fallback. The caller
+    /// must have approved this contract to spend at least `amountIn` of
+    /// `tokenIn`. Reverts `UnknownVenue` if `venue` is not whitelisted, or
+    /// reverts if the final output is below `amountOutMin`.
+    /// @param venue The proprietary venue to attempt the swap on first.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum acceptable amount of `tokenOut`.
+    /// @param recipient The address that will receive `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @return amountOut The amount of `tokenOut` actually received by `recipient`.
+    function swapViaVenueV1(
+        address venue,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
         uint256 deadline
     ) external returns (uint256 amountOut);
 
-    /// @notice Quotes `amount` of `tokenIn` against every supported venue
-    /// (the proprietary AMMs and the Uniswap V3 fallback) and returns the
-    /// best output along with the venue that produced it.
-    /// @dev Venues that revert when quoting are skipped. Reverts if no venue
-    /// can produce a quote. Not `view`: the Uniswap V3 QuoterV2 branch
-    /// prices via revert-based simulation. Call this via `eth_call`
-    /// (staticcall) from off-chain.
+    /// @notice Quotes `amount` of `tokenIn` against every venue (the
+    /// proprietary AMMs and the Uniswap V3 baseline) and returns the best
+    /// output along with the venue that produced it.
+    /// @dev Venues that revert when quoting are skipped. Reverts
+    /// `NoQuotesAvailable` if no venue can produce a quote. Not `view`: the
+    /// Uniswap V3 QuoterV2 branch prices via revert-based simulation. Call this
+    /// via `eth_call` (staticcall) from off-chain.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
-    /// @param uniswapFee The Uniswap V3 pool fee tier used when quoting the
-    /// `Venue.Fallback` branch; ignored by the proprietary AMM branches.
-    /// @return quote The best `tokenOut` amount across all venues.
-    /// @return venue The venue that produced `quote`.
-    function quote(
-        address tokenIn,
-        address tokenOut,
-        uint256 amount,
-        uint24 uniswapFee
-    ) external returns (uint256 quote, Venue venue);
-
-    /// @notice `quote` overload that uses the implementation's default
-    /// Uniswap V3 fee tier (`DEFAULT_FALLBACK_FEE`) for the `Venue.Fallback`
-    /// branch.
-    /// @dev Convenience wrapper for callers that don't want to pick a fee
-    /// tier. For pairs whose deepest pool is not at the default tier (e.g.
-    /// USDC/WETH on mainnet, which is `500`), prefer the 4-arg overload.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
-    /// @param amount The exact amount of `tokenIn` to quote against.
-    /// @return quote The best `tokenOut` amount across all venues.
-    /// @return venue The venue that produced `quote`.
-    function quote(
+    /// @return bestQuote The best `tokenOut` amount across all venues.
+    /// @return venue The venue that produced `bestQuote`; the Uniswap V3
+    /// SwapRouter address if the Uniswap baseline won.
+    function quoteV1(
         address tokenIn,
         address tokenOut,
         uint256 amount
-    ) external returns (uint256 quote, Venue venue);
+    ) external returns (uint256 bestQuote, address venue);
 
-    /// @notice Quotes `amount` of `tokenIn` against a single specified venue.
-    /// Not `view`: the Uniswap V3 fallback branch prices via revert-based
-    /// simulation, which is incompatible with `view`. Call this via
-    /// `eth_call` (staticcall) from off-chain.
-    ///
-    /// Reverts `UnknownVenue` if `venue` is not a recognized enum value.
-    /// Bubbles up any revert from the underlying venue (e.g. unsupported
-    /// pair, no liquidity, stale Kipseli oracle).
-    /// @param venue The venue to quote against.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
-    /// @param amount The exact amount of `tokenIn` to quote against.
-    /// @param uniswapFee The Uniswap V3 pool fee tier used when `venue` is
-    /// `Venue.Fallback`; ignored by the proprietary AMM branches.
-    /// @return amountOut The amount of `tokenOut` quoted by `venue`.
-    function quoteVenue(
-        Venue venue,
-        address tokenIn,
-        address tokenOut,
-        uint256 amount,
-        uint24 uniswapFee
-    ) external returns (uint256 amountOut);
-
-    /// @notice `quoteVenue` overload that uses the implementation's default
-    /// Uniswap V3 fee tier (`DEFAULT_FALLBACK_FEE`) when `venue` is
-    /// `Venue.Fallback`.
-    /// @dev Convenience wrapper for callers that don't want to pick a fee
-    /// tier. For pairs whose deepest pool is not at the default tier, prefer
-    /// the 5-arg overload.
-    /// @param venue The venue to quote against.
+    /// @notice Quotes `amount` of `tokenIn` against a single whitelisted
+    /// proprietary venue.
+    /// @dev Not `view`: a venue's quote source may price via revert-based
+    /// simulation. Call this via `eth_call` (staticcall) from off-chain.
+    /// Reverts `UnknownVenue` if `venue` is not a whitelisted proprietary AMM.
+    /// Bubbles up any revert from the underlying venue (e.g. unsupported pair,
+    /// no liquidity, stale Kipseli oracle).
+    /// @param venue The proprietary venue to quote against.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return amountOut The amount of `tokenOut` quoted by `venue`.
-    function quoteVenue(
-        Venue venue,
+    function quoteVenueV1(
+        address venue,
         address tokenIn,
         address tokenOut,
         uint256 amount


### PR DESCRIPTION
Replace the enum-based swap/quote API with the address-based V1 functions: swapV1, swapViaVenueV1, quoteV1, quoteVenueV1. 

This PR also drops the Venue enum. Venues are now identified by address. The whitelist is the three hardcoded PropAMMs (Fermi, Kipseli, Bebop) via _isVenue. This is meant to be extended in a future PR.

I also dropped the per-call uniswapFee argument. Uniswap fallback fee moves from the DEFAULT_FALLBACK_FEE constant to owner-settable fallbackFee storage (setFallbackFee), appended for a layout-safe UUPS upgrade.
