### PR TITLE
fix: update `swapViaSelectedVenuesV1` to default to uniswap in case of error

### DIFF
--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -166,12 +166,9 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
-    /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with
-    /// `swapV1`, the fallback remains as the transparent safety net inside `_coreSwap`.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and `QuoteBelowMinimum` 
-    /// before pulling funds when the best quote across `venues` is under `amountOutMin`; 
-    /// quotes are advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
-    /// balance delta.
+    /// `_pickBestVenueFrom`, and if any venue returns a quote that is at least
+    /// `amountOutMin`, then attempts to swap via that venue. Otherwise, it defaults
+    /// to swapping via Uniswap V3
     function swapViaSelectedVenuesV1(
         address[] calldata venues,
         address tokenIn,
@@ -183,10 +180,15 @@ contract PropAMMRouter is
     ) public whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
         // Fail fast before the on-chain requote; `_coreSwap` re-checks deadline.
         require(block.timestamp <= deadline, Expired());
+
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
-        // Reject when none of the selected venues could be priced (venue stays address(0)).
-        require(venue != address(0), NoQuotesAvailable());
-        require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
+
+        // Quote step "failed" (none of `venues` priced, or the best is below the
+        // minimum): route to the fallback venue, which `_coreSwap` runs directly.
+        if (venue == address(0) || bestQuote < amountOutMin) {
+            venue = fallbackSwapRouter;
+        }
+
         return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -183,8 +183,8 @@ contract PropAMMRouter is
 
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
 
-        // Quote step "failed" (none of `venues` priced, or the best is below the
-        // minimum): route to the fallback venue, which `_coreSwap` runs directly.
+        // If no quotes available, or the best quote is below the minimum,
+        // route to the fallback venue, which `_coreSwap` runs directly.
         if (venue == address(0) || bestQuote < amountOutMin) {
             venue = fallbackSwapRouter;
         }

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -81,8 +81,8 @@ interface IPropAMMRouter {
     /// venues. An on-chain requote across `venues` selects the best.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Venues that revert while quoting (including non-whitelisted
-    /// addresses) are skipped. The whole requote-and-swap over `venues` falls
-    /// back to the public venue if it fails for any reason.
+    /// addresses) are skipped. The public-venue fallback still applies as the
+    /// transparent safety net if the chosen proprietary venue fails to fill.
     /// Reverts only if even the public-venue fallback cannot deliver `amountOutMin`.
     /// @param venues The venues to consider — a subset of the available venues.
     /// @param tokenIn The token being sold.

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -81,12 +81,9 @@ interface IPropAMMRouter {
     /// venues. An on-chain requote across `venues` selects the best.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Venues that revert while quoting (including non-whitelisted
-    /// addresses) are skipped. The public-venue fallback still applies as the
-    /// transparent safety net if the chosen proprietary venue fails to fill.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and
-    /// `QuoteBelowMinimum` before pulling funds if the best quote across `venues`
-    /// is below `amountOutMin`, and re-checks `amountOutMin` against the
-    /// delivered balance delta after execution.
+    /// addresses) are skipped. The whole requote-and-swap over `venues` falls
+    /// back to the public venue if it fails for any reason.
+    /// Reverts only if even the public-venue fallback cannot deliver `amountOutMin`.
     /// @param venues The venues to consider — a subset of the available venues.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.


### PR DESCRIPTION
**Motivation**
The `swapViaSelectedVenuesV1` function reverts if none of the quotes offered by the selected venues can fill the swap. However, we want it to fall back to Uniswap V3 in that case.

**Description**
This PR updates the `swapViaSelectedVenuesV1` function so that it defaults to Uniswap V3 in case none of the selected venues can fill the swap.