### PR TITLE
Use different fee tier per pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Venues are identified **by address**: the three proprietary AMM routers (FermiSw
 
 The Uniswap V3 fallback prices and swaps at a per-pair fee tier, resolved on every quote and swap: the owner-set override for that pair if one exists, otherwise the global `fallbackFee` (`3000`, i.e. the 0.30% tier, by default). Callers never pass a fee. The owner sets overrides with `setPairFee(tokenA, tokenB, fee)` or `setPairFees(tokenA[], tokenB[], fee[])` (order-independent; `fee == 0` clears an override), and retunes the global default with `setFallbackFee` — all without a contract upgrade. This lets stablecoin pairs use their tight tier (e.g. USDC/USDT at `100`) while volatile pairs keep `3000`/`10000`. Query the effective tier with `resolvedFee(tokenIn, tokenOut)` and the raw override with `getPairFee(tokenA, tokenB)`.
 
+A from-scratch deploy is pre-seeded by `initialize` with the deep mainnet tiers — USDT/USDC at `100`, USDT/WETH and USDC/WETH at `500` — so no post-deploy seeding step is needed. This runs only in `initialize` (initializer-gated), so it does not re-apply when an existing proxy upgrades; those deployments still seed via `scripts/SeedStablePairs.s.sol`. The owner can clear or retune any seeded tier afterward with `setPairFee`.
+
 ### Kipseli quote caveat
 
 Kipseli does not expose a usable on-chain quote function. To price it, the router calls `Kipseli.simulateKipseliSwap`, which executes a real swap and then reverts with the resulting `amountOut` ABI-encoded in the revert payload. The router decodes that payload to recover the quote.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Both functions are restricted to the proxy owner (the address passed as `ROUTER_
 
 Upgrades are authorized by the proxy owner via `_authorizeUpgrade` (`onlyOwner`), so they must be broadcast from the account that holds ownership of the proxy (the address passed as `ROUTER_OWNER` at deployment, or whoever currently holds ownership after an `Ownable2Step` handoff).
 
+> **Per-pair fee precondition:** Unconfigured pairs resolve their Uniswap fallback tier to the global `fallbackFee`, which is set (`= 3000`) only in `initialize` — i.e. on a fresh deploy. Before upgrading an existing proxy to a version that includes the per-pair fee map, confirm the live `fallbackFee` is non-zero. Otherwise the fallback resolves to tier `0` (invalid on Uniswap V3) for every unconfigured pair and reverts. If the proxy predates `fallbackFee` (an enum-era deployment), ship a `reinitializer` that backfills `fallbackFee = 3000` when it reads `0` and pass its calldata in `scripts/Upgrade.s.sol` (see "Writing a new implementation" and "Running the upgrade" below).
+
 ### Writing a new implementation
 
 Place the new implementation under `src/` (for example `src/PropAMMRouterV2.sol`). It must:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Venues are identified **by address**: the three proprietary AMM routers (FermiSw
 - `quoteVenueV1(venue, tokenIn, tokenOut, amount)`: quotes a single venue by address. Reverts `UnknownVenue` for any address that is neither a proprietary AMM nor the SwapRouter02 fallback, and bubbles up any underlying venue revert.
 - `quoteSelectedVenuesV1(venues, tokenIn, tokenOut, amountIn)`: quotes only the caller-supplied `venues` subset and returns the best `(bestAmountOut, bestVenue)`. Venues that revert (including non-whitelisted addresses) are skipped; reverts `NoQuotesAvailable` if none of them can be priced.
 
-The Uniswap V3 fallback always prices and swaps at the owner-settable `fallbackFee` pool tier (`3000`, i.e. the 0.30% tier, by default) — callers never pass a fee. For pairs whose deepest Uniswap V3 pool is not at the 0.30% tier (e.g. USDC/WETH on mainnet, which is `500`), the owner retunes it with `setFallbackFee` (no contract upgrade required).
+The Uniswap V3 fallback prices and swaps at a per-pair fee tier, resolved on every quote and swap: the owner-set override for that pair if one exists, otherwise the global `fallbackFee` (`3000`, i.e. the 0.30% tier, by default). Callers never pass a fee. The owner sets overrides with `setPairFee(tokenA, tokenB, fee)` or `setPairFees(tokenA[], tokenB[], fee[])` (order-independent; `fee == 0` clears an override), and retunes the global default with `setFallbackFee` — all without a contract upgrade. This lets stablecoin pairs use their tight tier (e.g. USDC/USDT at `100`) while volatile pairs keep `3000`/`10000`. Query the effective tier with `resolvedFee(tokenIn, tokenOut)` and the raw override with `getPairFee(tokenA, tokenB)`.
 
 ### Kipseli quote caveat
 
@@ -100,8 +100,8 @@ OVERRIDES=$(curl -s -X POST https://eu.rpc.titanbuilder.xyz \
       ')
 
 # 2. eth_call PropAMMRouter.quoteVenueV1(venue, WETH, USDC, 1e18) with the overrides.
-#    The Uniswap V3 fallback always prices at the owner-set `fallbackFee` tier
-#    (3000 by default); there is no per-call fee argument.
+#    The Uniswap V3 fallback prices at the per-pair tier (the override for this
+#    pair, else the global `fallbackFee`, 3000 by default); no per-call fee arg.
 DATA=$(cast calldata "quoteVenueV1(address,address,address,uint256)" $VENUE_ADDR $WETH $USDC 1000000000000000000)
 
 curl -s -X POST $RPC_URL -H "Content-Type: application/json" \

--- a/scripts/SeedStablePairs.s.sol
+++ b/scripts/SeedStablePairs.s.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.35;
 import "forge-std/Script.sol";
 import {PropAMMRouter} from "../src/PropAMMRouter.sol";
 
-/// @notice Seeds owner-curated Uniswap V3 fallback fee tiers for the deep mainnet
-/// stablecoin pairs. Run by ROUTER_OWNER after deployment (setPairFees is onlyOwner).
-/// @dev VERIFY the deepest live tier per pair before mainnet use — DAI/USDT 100 vs
-/// 500 especially (its 0.05% pool has historically been deeper).
+/// @notice Seeds the owner-curated Uniswap V3 fallback fee tiers for the deep
+/// mainnet pairs: the stablecoin pair plus the two ETH/stable pairs. Run by
+/// ROUTER_OWNER after deployment (setPairFees is onlyOwner).
+/// @dev Mirrors the contract's `_seedDefaultPairFees` (run in `initialize`), so an
+/// in-place proxy upgrade — which never re-runs `initialize` — ends up with the
+/// same tier map as a from-scratch deploy. Keep the two in sync when either changes.
 contract SeedStablePairs is Script {
     address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
-    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
     /// @notice The pairs/tiers to seed. Edit here; both `run()` and the test use this.
     function seedData() public pure returns (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees) {
@@ -19,17 +21,17 @@ contract SeedStablePairs is Script {
         tokenB = new address[](3);
         fees = new uint24[](3);
 
-        // USDC/USDT — deepest at 0.01%.
+        // USDC/USDT — stablecoin pair, deepest at 0.01%.
         tokenA[0] = USDC;
         tokenB[0] = USDT;
         fees[0] = 100;
-        // USDC/DAI — deepest at 0.01%.
+        // USDC/WETH — ETH/stable, deepest at 0.05%.
         tokenA[1] = USDC;
-        tokenB[1] = DAI;
-        fees[1] = 100;
-        // DAI/USDT — 0.05% default (historically the deeper pool); VERIFY vs 100 against live liquidity before mainnet.
-        tokenA[2] = DAI;
-        tokenB[2] = USDT;
+        tokenB[1] = WETH;
+        fees[1] = 500;
+        // USDT/WETH — ETH/stable, deepest at 0.05%.
+        tokenA[2] = USDT;
+        tokenB[2] = WETH;
         fees[2] = 500;
     }
 

--- a/scripts/SeedStablePairs.s.sol
+++ b/scripts/SeedStablePairs.s.sol
@@ -35,6 +35,7 @@ contract SeedStablePairs is Script {
         address proxy = vm.envAddress("ROUTER_PROXY");
         (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees) = seedData();
 
+        // The broadcaster MUST be ROUTER_OWNER — setPairFees is onlyOwner.
         vm.startBroadcast();
         PropAMMRouter(proxy).setPairFees(tokenA, tokenB, fees);
         vm.stopBroadcast();

--- a/scripts/SeedStablePairs.s.sol
+++ b/scripts/SeedStablePairs.s.sol
@@ -27,8 +27,8 @@ contract SeedStablePairs is Script {
         tokenA[0] = USDC; tokenB[0] = USDT; fees[0] = 100;
         // USDC/DAI — deepest at 0.01%.
         tokenA[1] = USDC; tokenB[1] = DAI; fees[1] = 100;
-        // DAI/USDT — VERIFY 100 vs 500 against live liquidity before mainnet.
-        tokenA[2] = DAI; tokenB[2] = USDT; fees[2] = 100;
+        // DAI/USDT — 0.05% default (historically the deeper pool); VERIFY vs 100 against live liquidity before mainnet.
+        tokenA[2] = DAI; tokenB[2] = USDT; fees[2] = 500;
     }
 
     function run() public {

--- a/scripts/SeedStablePairs.s.sol
+++ b/scripts/SeedStablePairs.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.35;
+
+import "forge-std/Script.sol";
+import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+
+/// @notice Seeds owner-curated Uniswap V3 fallback fee tiers for the deep mainnet
+/// stablecoin pairs. Run by ROUTER_OWNER after deployment (setPairFees is onlyOwner).
+/// @dev VERIFY the deepest live tier per pair before mainnet use — DAI/USDT 100 vs
+/// 500 especially (its 0.05% pool has historically been deeper).
+contract SeedStablePairs is Script {
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+    /// @notice The pairs/tiers to seed. Edit here; both `run()` and the test use this.
+    function seedData()
+        public
+        pure
+        returns (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees)
+    {
+        tokenA = new address[](3);
+        tokenB = new address[](3);
+        fees = new uint24[](3);
+
+        // USDC/USDT — deepest at 0.01%.
+        tokenA[0] = USDC; tokenB[0] = USDT; fees[0] = 100;
+        // USDC/DAI — deepest at 0.01%.
+        tokenA[1] = USDC; tokenB[1] = DAI; fees[1] = 100;
+        // DAI/USDT — VERIFY 100 vs 500 against live liquidity before mainnet.
+        tokenA[2] = DAI; tokenB[2] = USDT; fees[2] = 100;
+    }
+
+    function run() public {
+        address proxy = vm.envAddress("ROUTER_PROXY");
+        (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees) = seedData();
+
+        vm.startBroadcast();
+        PropAMMRouter(proxy).setPairFees(tokenA, tokenB, fees);
+        vm.stopBroadcast();
+
+        console.log("seeded pair fees on proxy:", proxy);
+    }
+}

--- a/scripts/SeedStablePairs.s.sol
+++ b/scripts/SeedStablePairs.s.sol
@@ -14,21 +14,23 @@ contract SeedStablePairs is Script {
     address constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
     /// @notice The pairs/tiers to seed. Edit here; both `run()` and the test use this.
-    function seedData()
-        public
-        pure
-        returns (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees)
-    {
+    function seedData() public pure returns (address[] memory tokenA, address[] memory tokenB, uint24[] memory fees) {
         tokenA = new address[](3);
         tokenB = new address[](3);
         fees = new uint24[](3);
 
         // USDC/USDT — deepest at 0.01%.
-        tokenA[0] = USDC; tokenB[0] = USDT; fees[0] = 100;
+        tokenA[0] = USDC;
+        tokenB[0] = USDT;
+        fees[0] = 100;
         // USDC/DAI — deepest at 0.01%.
-        tokenA[1] = USDC; tokenB[1] = DAI; fees[1] = 100;
+        tokenA[1] = USDC;
+        tokenB[1] = DAI;
+        fees[1] = 100;
         // DAI/USDT — 0.05% default (historically the deeper pool); VERIFY vs 100 against live liquidity before mainnet.
-        tokenA[2] = DAI; tokenB[2] = USDT; fees[2] = 500;
+        tokenA[2] = DAI;
+        tokenB[2] = USDT;
+        fees[2] = 500;
     }
 
     function run() public {

--- a/scripts/Upgrade.s.sol
+++ b/scripts/Upgrade.s.sol
@@ -11,6 +11,13 @@ contract Upgrade is Script {
 
         vm.startBroadcast();
 
+        // Per-pair fee precondition: unconfigured pairs resolve their Uniswap
+        // fallback tier to `fallbackFee`, which is set (=3000) only in `initialize`
+        // (fresh deploy). Before upgrading an existing proxy, confirm the live
+        // `fallbackFee` is non-zero — a 0 value (e.g. an enum-era proxy that never
+        // had `fallbackFee`) makes the fallback resolve to tier 0 (invalid) and
+        // revert for all unconfigured pairs. If so, ship a reinitializer that
+        // backfills `fallbackFee = 3000` and pass its calldata below instead of "".
         Upgrades.upgradeProxy(
             proxy,
             newImplName,

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -76,6 +76,8 @@ contract PropAMMRouter is
     error InvalidFallbackFee(uint24 fee);
     /// @notice Thrown when an address argument that must be non-zero is zero.
     error ZeroAddress();
+    /// @notice Thrown when `setPairFees` is given arrays of unequal length.
+    error ArrayLengthMismatch();
 
     // `Swapped` is declared in IPropAMMRouter (part of the published interface)
     // and inherited here. The operational events below are implementation
@@ -570,6 +572,23 @@ contract PropAMMRouter is
     /// @param fee Fee tier in hundredths of a bip (e.g. `100` for 0.01%), or 0 to clear.
     function setPairFee(address tokenA, address tokenB, uint24 fee) external onlyOwner {
         _setPairFee(tokenA, tokenB, fee);
+    }
+
+    /// @notice Sets (or clears) per-pair fallback fees for several pairs in one call.
+    /// @dev Owner-gated. The three arrays are zipped index-wise and must be equal
+    /// length. Each entry follows the same rules as `setPairFee` (0 clears) and emits
+    /// its own `PairFeeUpdated`.
+    /// @param tokenA Array whose i-th element is one token of pair `i`.
+    /// @param tokenB Array whose i-th element is the other token of pair `i`.
+    /// @param fees Array whose i-th element is the tier for pair `i`, or 0 to clear.
+    function setPairFees(address[] calldata tokenA, address[] calldata tokenB, uint24[] calldata fees)
+        external
+        onlyOwner
+    {
+        require(tokenA.length == tokenB.length && tokenB.length == fees.length, ArrayLengthMismatch());
+        for (uint256 i = 0; i < fees.length; i++) {
+            _setPairFee(tokenA[i], tokenB[i], fees[i]);
+        }
     }
 
     /// @dev Shared validate-emit-store for both setters. Mirrors `setFallbackFee`'s

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -372,7 +372,7 @@ contract PropAMMRouter is
         address recipient
     ) private returns (uint256 amountOut) {
         amountOut = UniV3Router.swapExactIn(
-            tokenIn, tokenOut, fallbackFee, amountIn, amountOutMin, recipient, fallbackSwapRouter
+            tokenIn, tokenOut, _resolveFee(tokenIn, tokenOut), amountIn, amountOutMin, recipient, fallbackSwapRouter
         );
         return amountOut;
     }
@@ -404,7 +404,7 @@ contract PropAMMRouter is
         } else if (venue == BEBOP_ROUTER) {
             amountOut = IBebopRouter(BEBOP_ROUTER).quote(tokenIn, tokenOut, amount);
         } else if (venue == fallbackSwapRouter) {
-            amountOut = UniV3Router.quoteExactIn(tokenIn, tokenOut, fallbackFee, amount, fallbackQuoter);
+            amountOut = UniV3Router.quoteExactIn(tokenIn, tokenOut, _resolveFee(tokenIn, tokenOut), amount, fallbackQuoter);
         } else {
             revert UnknownVenue();
         }
@@ -432,7 +432,7 @@ contract PropAMMRouter is
     /// @param amount The exact amount of `tokenIn` to quote against.
     /// @return amountOut The amount of `tokenOut` the Uniswap V3 swap would produce.
     function quoteUniswapV3(address tokenIn, address tokenOut, uint256 amount) external returns (uint256 amountOut) {
-        return UniV3Router.quoteExactIn(tokenIn, tokenOut, fallbackFee, amount, fallbackQuoter);
+        return UniV3Router.quoteExactIn(tokenIn, tokenOut, _resolveFee(tokenIn, tokenOut), amount, fallbackQuoter);
     }
 
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -355,8 +355,9 @@ contract PropAMMRouter is
     /// @notice Executes the fallback swap on Uniswap V3 with funds already held
     /// by this contract.
     /// @dev Assumes the router already holds `amountIn` of `tokenIn` — pulled
-    /// once by `_coreSwap` before the try/catch. Uses the owner-set `fallbackFee`
-    /// pool tier. `UniV3Router.swapExactIn` only approves `fallbackSwapRouter`
+    /// once by `_coreSwap` before the try/catch. Uses the per-pair resolved fee
+    /// tier (`_resolveFee`: the pair override if set, otherwise the global
+    /// `fallbackFee`). `UniV3Router.swapExactIn` only approves `fallbackSwapRouter`
     /// and executes the swap; it does not pull from `msg.sender`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
@@ -423,8 +424,8 @@ contract PropAMMRouter is
         require(bestAmountOut > 0, NoQuotesAvailable());
     }
 
-    /// @notice Quotes the Uniswap V3 fallback for the pair at the current
-    /// `fallbackFee` tier.
+    /// @notice Quotes the Uniswap V3 fallback for the pair at its resolved fee
+    /// tier (the per-pair override if set, otherwise the global `fallbackFee`).
     /// @dev External so `_pickBestVenue` and `quoteV1` can wrap it in a
     /// `try/catch` (an internal library call can't be caught).
     /// @param tokenIn The address of the token being sold.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -45,6 +45,15 @@ contract PropAMMRouter is
     /// to the global `fallbackFee`. Owner-settable via `setPairFee` / `setPairFees`.
     mapping(bytes32 pairKey => uint24 fee) private _pairFee;
 
+    // Mainnet token addresses for the default per-pair fallback tiers seeded by
+    // `initialize` (see `_seedDefaultPairFees`). Mainnet-specific by design: on
+    // other chains these point at the wrong tokens, which is harmless — they are
+    // only consulted for these exact addresses, and the owner can clear/override
+    // any entry via `setPairFee`.
+    address private constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address private constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address private constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
     /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
     /// contract itself, i.e. outside of the `try`-wrapped self-call made by
     /// `_coreSwap`.
@@ -125,6 +134,10 @@ contract PropAMMRouter is
     /// *subsequent* transfers via `transferOwnership` / `acceptOwnership`.
     /// Controls `_authorizeUpgrade` and any owner-gated administrative paths.
     /// Reverts if zero (enforced by `__Ownable_init`).
+    /// @dev Also seeds the deep mainnet Uniswap V3 fallback tiers via
+    /// `_seedDefaultPairFees`, so a from-scratch deploy is pre-configured without a
+    /// separate owner-run seeding step. Runs only here (initializer-gated), so it
+    /// never re-applies on a UUPS upgrade of an existing proxy.
     function initialize(address fallbackSwapRouter_, address fallbackQuoter_, address owner_) public initializer {
         require(fallbackSwapRouter_ != address(0), ZeroAddress());
         require(fallbackQuoter_ != address(0), ZeroAddress());
@@ -134,6 +147,19 @@ contract PropAMMRouter is
         __Ownable_init(owner_);
         __Ownable2Step_init();
         __Pausable_init();
+        _seedDefaultPairFees();
+    }
+
+    /// @notice Seeds the deep mainnet Uniswap V3 fallback fee tiers so a
+    /// from-scratch deploy is configured without a separate owner-run seeding step.
+    /// @dev Routes through `_setPairFee`, so each seeded pair clears the same
+    /// validation and emits `PairFeeUpdated(tokenA, tokenB, 0, fee)` — an indexer
+    /// sees the initial config exactly as if the owner had set it. Tiers are the
+    /// deepest live mainnet pools: stable/stable at 0.01%, ETH/stable at 0.05%.
+    function _seedDefaultPairFees() private {
+        _setPairFee(USDT, USDC, 100); // stablecoin pair — deepest at 0.01%
+        _setPairFee(USDT, WETH, 500); // ETH/stable — deepest at 0.05%
+        _setPairFee(USDC, WETH, 500); // ETH/stable — deepest at 0.05%
     }
 
     /// @inheritdoc IPropAMMRouter

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -93,6 +93,12 @@ contract PropAMMRouter is
     /// @param oldQuoter The previous `fallbackQuoter`.
     /// @param newQuoter The new `fallbackQuoter`.
     event FallbackQuoterUpdated(address indexed oldQuoter, address indexed newQuoter);
+    /// @notice Emitted when the owner sets or clears a per-pair fallback fee.
+    /// @param tokenA One token of the pair (as supplied to the setter).
+    /// @param tokenB The other token of the pair (as supplied to the setter).
+    /// @param oldFee The previous override (0 if it was unset).
+    /// @param newFee The new override (0 means cleared / use global default).
+    event PairFeeUpdated(address indexed tokenA, address indexed tokenB, uint24 oldFee, uint24 newFee);
     /// @notice Emitted when the owner rescues tokens stranded on the router.
     /// @param token The ERC-20 rescued.
     /// @param to The recipient of the rescued tokens.
@@ -552,6 +558,28 @@ contract PropAMMRouter is
     /// @param tokenOut The token being bought.
     function resolvedFee(address tokenIn, address tokenOut) external view returns (uint24) {
         return _resolveFee(tokenIn, tokenOut);
+    }
+
+    /// @notice Sets (or clears) the Uniswap V3 fallback fee tier for a specific pair.
+    /// @dev Owner-gated. Order-independent. Pass `fee == 0` to clear the override and
+    /// revert the pair to the global `fallbackFee`. A tier with no pool simply makes
+    /// the fallback quote revert and be skipped for that pair — it does not corrupt
+    /// state.
+    /// @param tokenA One token of the pair.
+    /// @param tokenB The other token of the pair.
+    /// @param fee Fee tier in hundredths of a bip (e.g. `100` for 0.01%), or 0 to clear.
+    function setPairFee(address tokenA, address tokenB, uint24 fee) external onlyOwner {
+        _setPairFee(tokenA, tokenB, fee);
+    }
+
+    /// @dev Shared validate-emit-store for both setters. Mirrors `setFallbackFee`'s
+    /// upper bound and reuses `InvalidFallbackFee`, but allows 0 (the "unset"
+    /// sentinel that clears the override).
+    function _setPairFee(address tokenA, address tokenB, uint24 fee) private {
+        require(fee < 1_000_000, InvalidFallbackFee(fee)); // 0 allowed = clear
+        bytes32 key = _pairKey(tokenA, tokenB);
+        emit PairFeeUpdated(tokenA, tokenB, _pairFee[key], fee);
+        _pairFee[key] = fee;
     }
 
     /// @notice Repoints the address used by the fallback route.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -508,13 +508,12 @@ contract PropAMMRouter is
         return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER || venue == fallbackSwapRouter;
     }
 
-    /// @notice Canonical key for a token pair, order-independent.
-    /// @dev Uniswap V3 pools are symmetric (one pool, `token0 < token1`, serves
-    /// both directions), so {A,B} and {B,A} share one entry.
+    /// @dev Canonical key for a token pair, order-independent. Uniswap V3 pools
+    /// are symmetric (one pool, `token0 < token1`, serves both directions), so
+    /// {A,B} and {B,A} share one entry.
     function _pairKey(address tokenA, address tokenB) private pure returns (bytes32) {
-        return tokenA < tokenB
-            ? keccak256(abi.encodePacked(tokenA, tokenB))
-            : keccak256(abi.encodePacked(tokenB, tokenA));
+        (address a, address b) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+        return keccak256(abi.encodePacked(a, b));
     }
 
     /// @notice Resolves the Uniswap V3 fallback fee for a pair: the per-pair

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -40,6 +40,10 @@ contract PropAMMRouter is
     address public fallbackQuoter;
     /// @notice Fee for the fallback venue.
     uint24 public fallbackFee;
+    /// @notice Per-pair Uniswap V3 fallback fee override, keyed by the sorted
+    /// token pair (see `_pairKey`). A value of 0 means "unset" — the pair resolves
+    /// to the global `fallbackFee`. Owner-settable via `setPairFee` / `setPairFees`.
+    mapping(bytes32 pairKey => uint24 fee) private _pairFee;
 
     /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
     /// contract itself, i.e. outside of the `try`-wrapped self-call made by
@@ -504,6 +508,25 @@ contract PropAMMRouter is
         return venue == FERMI_ROUTER || venue == KIPSELI_PAMM || venue == BEBOP_ROUTER || venue == fallbackSwapRouter;
     }
 
+    /// @notice Canonical key for a token pair, order-independent.
+    /// @dev Uniswap V3 pools are symmetric (one pool, `token0 < token1`, serves
+    /// both directions), so {A,B} and {B,A} share one entry.
+    function _pairKey(address tokenA, address tokenB) private pure returns (bytes32) {
+        return tokenA < tokenB
+            ? keccak256(abi.encodePacked(tokenA, tokenB))
+            : keccak256(abi.encodePacked(tokenB, tokenA));
+    }
+
+    /// @notice Resolves the Uniswap V3 fallback fee for a pair: the per-pair
+    /// override if set, otherwise the global `fallbackFee`.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @return fee The effective fee tier in hundredths of a bip.
+    function _resolveFee(address tokenIn, address tokenOut) private view returns (uint24 fee) {
+        fee = _pairFee[_pairKey(tokenIn, tokenOut)];
+        if (fee == 0) fee = fallbackFee;
+    }
+
     /// @dev Restricts UUPS upgrades to the contract owner set in `initialize`.
     function _authorizeUpgrade(address) internal override onlyOwner {}
 
@@ -515,6 +538,21 @@ contract PropAMMRouter is
         require(fee != 0 && fee < 1_000_000, InvalidFallbackFee(fee));
         emit FallbackFeeUpdated(fallbackFee, fee);
         fallbackFee = fee;
+    }
+
+    /// @notice Returns the raw per-pair fee override for a pair (0 if unset).
+    /// @param tokenA One token of the pair.
+    /// @param tokenB The other token of the pair.
+    function getPairFee(address tokenA, address tokenB) external view returns (uint24) {
+        return _pairFee[_pairKey(tokenA, tokenB)];
+    }
+
+    /// @notice Returns the effective Uniswap V3 fallback tier the router will use
+    /// for a pair: the per-pair override if set, otherwise the global `fallbackFee`.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    function resolvedFee(address tokenIn, address tokenOut) external view returns (uint24) {
+        return _resolveFee(tokenIn, tokenOut);
     }
 
     /// @notice Repoints the address used by the fallback route.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -17,7 +17,7 @@ import {KIPSELI_QUOTER, IKipseliQuoter} from "./interfaces/IKipseliQuoter.sol";
 import {UniV3Router} from "./libraries/UniV3Router.sol";
 
 /// @title PropAMMRouter
-/// @notice Routes single-hop swaps to a propAMM and falls back through a fallback 
+/// @notice Routes single-hop swaps to a propAMM and falls back through a fallback
 /// venue if the chosen venue reverts.
 /// @dev Designed to live behind a UUPS proxy. The fallback path is wired at
 /// initialization via `fallbackSwapRouter` and `fallbackQuoter`
@@ -32,7 +32,7 @@ contract PropAMMRouter is
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
-    /// @notice Fallback venue address. 
+    /// @notice Fallback venue address.
     /// Owner-settable via `setFallbackSwapRouter`.
     address public fallbackSwapRouter;
     /// @notice Fallback venue address used to price the fallback route.
@@ -161,7 +161,7 @@ contract PropAMMRouter is
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Swaps via the `venue`. It must be a callable venue or the 
+    /// @dev Swaps via the `venue`. It must be a callable venue or the
     /// fallback venue named by the `fallbackSwapRouter` address.
     function swapViaVenueV1(
         address venue,
@@ -180,8 +180,8 @@ contract PropAMMRouter is
     /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
     /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with
     /// `swapV1`, the fallback remains as the transparent safety net inside `_coreSwap`.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and `QuoteBelowMinimum` 
-    /// before pulling funds when the best quote across `venues` is under `amountOutMin`; 
+    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and `QuoteBelowMinimum`
+    /// before pulling funds when the best quote across `venues` is under `amountOutMin`;
     /// quotes are advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
     /// balance delta.
     function swapViaSelectedVenuesV1(
@@ -206,7 +206,7 @@ contract PropAMMRouter is
     /// and recovering via the fallback if it fails.
     /// @dev Shared core for `swapV1` and `swapViaVenueV1`; unguarded so the two
     /// public entrypoints can each apply `whenNotPaused`/`nonReentrant` without
-    /// re-entering the guard through one another. 
+    /// re-entering the guard through one another.
     /// @param venue The propAMM to attempt first, or `fallbackSwapRouter`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
@@ -405,7 +405,8 @@ contract PropAMMRouter is
         } else if (venue == BEBOP_ROUTER) {
             amountOut = IBebopRouter(BEBOP_ROUTER).quote(tokenIn, tokenOut, amount);
         } else if (venue == fallbackSwapRouter) {
-            amountOut = UniV3Router.quoteExactIn(tokenIn, tokenOut, _resolveFee(tokenIn, tokenOut), amount, fallbackQuoter);
+            amountOut =
+                UniV3Router.quoteExactIn(tokenIn, tokenOut, _resolveFee(tokenIn, tokenOut), amount, fallbackQuoter);
         } else {
             revert UnknownVenue();
         }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -241,6 +241,7 @@ contract PropAMMRouterPairFeeTest is Test {
 
         for (uint256 i = 0; i < a.length; i++) {
             assertEq(router.resolvedFee(a[i], b[i]), f[i]);
+            assertEq(router.getPairFee(a[i], b[i]), f[i]);
             // order-independence holds for the seeded pairs too
             assertEq(router.resolvedFee(b[i], a[i]), f[i]);
         }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -113,8 +113,12 @@ contract PropAMMRouterPairFeeTest is Test {
         address[] memory a = new address[](2);
         address[] memory b = new address[](2);
         uint24[] memory f = new uint24[](2);
-        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;
-        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 500;
+        a[0] = address(tokenIn);
+        b[0] = address(tokenOut);
+        f[0] = 100;
+        a[1] = address(tokenOut);
+        b[1] = address(0x1234);
+        f[1] = 500;
 
         router.setPairFees(a, b, f);
 
@@ -126,8 +130,12 @@ contract PropAMMRouterPairFeeTest is Test {
         address[] memory a = new address[](2);
         address[] memory b = new address[](2);
         uint24[] memory f = new uint24[](2);
-        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;
-        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 500;
+        a[0] = address(tokenIn);
+        b[0] = address(tokenOut);
+        f[0] = 100;
+        a[1] = address(tokenOut);
+        b[1] = address(0x1234);
+        f[1] = 500;
 
         vm.expectEmit(true, true, false, true, address(router));
         emit PairFeeUpdated(address(tokenIn), address(tokenOut), 0, 100);
@@ -149,7 +157,9 @@ contract PropAMMRouterPairFeeTest is Test {
         address[] memory a = new address[](1);
         address[] memory b = new address[](1);
         uint24[] memory f = new uint24[](1);
-        a[0] = address(tokenIn); b[0] = address(tokenOut); f[0] = 1_000_000;
+        a[0] = address(tokenIn);
+        b[0] = address(tokenOut);
+        f[0] = 1_000_000;
         vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.InvalidFallbackFee.selector, uint24(1_000_000)));
         router.setPairFees(a, b, f);
     }
@@ -167,8 +177,12 @@ contract PropAMMRouterPairFeeTest is Test {
         address[] memory a = new address[](2);
         address[] memory b = new address[](2);
         uint24[] memory f = new uint24[](2);
-        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;       // valid
-        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 1_000_000; // invalid
+        a[0] = address(tokenIn); // valid
+        b[0] = address(tokenOut);
+        f[0] = 100;
+        a[1] = address(tokenOut); // invalid
+        b[1] = address(0x1234);
+        f[1] = 1_000_000;
 
         vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.InvalidFallbackFee.selector, uint24(1_000_000)));
         router.setPairFees(a, b, f);
@@ -233,8 +247,8 @@ contract PropAMMRouterPairFeeTest is Test {
         (uint256 amountOut, address executedVenue) =
             router.swapV1(address(tokenIn), address(tokenOut), 1000, 900, recipient, block.timestamp + 1);
 
-        assertEq(mockRouter.lastFee(), 100);               // executed at the resolved per-pair tier
-        assertEq(executedVenue, address(mockRouter));      // fallbackSwapRouter won
+        assertEq(mockRouter.lastFee(), 100); // executed at the resolved per-pair tier
+        assertEq(executedVenue, address(mockRouter)); // fallbackSwapRouter won
         assertEq(amountOut, 1000);
         assertEq(tokenOut.balanceOf(recipient), 1000);
     }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -42,4 +42,12 @@ contract PropAMMRouterPairFeeTest is Test {
         assertEq(router.fallbackSwapRouter(), address(mockRouter));
         assertEq(router.fallbackQuoter(), address(mockQuoter));
     }
+
+    function test_resolvedFee_unset_returnsGlobalDefault() public view {
+        assertEq(router.resolvedFee(address(tokenIn), address(tokenOut)), 3000);
+    }
+
+    function test_getPairFee_unset_returnsZero() public view {
+        assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 0);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockSwapRouter02} from "./mocks/MockSwapRouter02.sol";
+import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
+
+contract PropAMMRouterPairFeeTest is Test {
+    PropAMMRouter internal router;
+    MockSwapRouter02 internal mockRouter;
+    MockQuoterV2 internal mockQuoter;
+    MockERC20 internal tokenIn;
+    MockERC20 internal tokenOut;
+
+    address internal owner = address(this);
+    address internal stranger = address(0xBEEF);
+    address internal recipient = address(0xCAFE);
+
+    // Re-declared locally so vm.expectEmit can match the router's emit.
+    event PairFeeUpdated(address indexed tokenA, address indexed tokenB, uint24 oldFee, uint24 newFee);
+
+    function setUp() public {
+        mockRouter = new MockSwapRouter02();
+        mockQuoter = new MockQuoterV2();
+        tokenIn = new MockERC20("TokenIn", "TIN");
+        tokenOut = new MockERC20("TokenOut", "TOUT");
+
+        PropAMMRouter impl = new PropAMMRouter();
+        bytes memory initData =
+            abi.encodeCall(PropAMMRouter.initialize, (address(mockRouter), address(mockQuoter), owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), initData);
+        router = PropAMMRouter(address(proxy));
+    }
+
+    function test_setUp_initialized() public view {
+        assertEq(router.owner(), owner);
+        assertEq(router.fallbackFee(), 3000);
+        assertEq(router.fallbackSwapRouter(), address(mockRouter));
+        assertEq(router.fallbackQuoter(), address(mockQuoter));
+    }
+}

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -169,4 +169,50 @@ contract PropAMMRouterPairFeeTest is Test {
         // entry 0 must NOT have been committed (whole batch rolled back)
         assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 0);
     }
+
+    function test_quoteUniswapV3_usesResolvedFee() public {
+        mockQuoter.setAmountOut(1000);
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        router.quoteUniswapV3(address(tokenIn), address(tokenOut), 1 ether);
+        assertEq(mockQuoter.lastFee(), 100);
+    }
+
+    function test_quoteUniswapV3_unconfigured_usesGlobalFee() public {
+        mockQuoter.setAmountOut(1000);
+        router.quoteUniswapV3(address(tokenIn), address(tokenOut), 1 ether);
+        assertEq(mockQuoter.lastFee(), 3000);
+    }
+
+    function test_quoteVenueV1_fallback_usesResolvedFee() public {
+        mockQuoter.setAmountOut(1000);
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        router.quoteVenueV1(address(mockRouter), address(tokenIn), address(tokenOut), 1 ether);
+        assertEq(mockQuoter.lastFee(), 100);
+    }
+
+    function test_swapViaFallback_usesResolvedFee() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        mockRouter.setAmountOut(1000);
+        tokenIn.mint(address(this), 1000);
+        tokenIn.approve(address(router), 1000);
+
+        router.swapViaVenueV1(
+            address(mockRouter), address(tokenIn), address(tokenOut), 1000, 900, recipient, block.timestamp + 1
+        );
+
+        assertEq(mockRouter.lastFee(), 100);
+        assertEq(tokenOut.balanceOf(recipient), 1000);
+    }
+
+    function test_swapViaFallback_unconfigured_usesGlobalFee() public {
+        mockRouter.setAmountOut(1000);
+        tokenIn.mint(address(this), 1000);
+        tokenIn.approve(address(router), 1000);
+
+        router.swapViaVenueV1(
+            address(mockRouter), address(tokenIn), address(tokenOut), 1000, 900, recipient, block.timestamp + 1
+        );
+
+        assertEq(mockRouter.lastFee(), 3000);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -7,6 +7,7 @@ import {PropAMMRouter} from "../src/PropAMMRouter.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockSwapRouter02} from "./mocks/MockSwapRouter02.sol";
 import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
+import {SeedStablePairs} from "../scripts/SeedStablePairs.s.sol";
 
 contract PropAMMRouterPairFeeTest is Test {
     PropAMMRouter internal router;
@@ -230,5 +231,18 @@ contract PropAMMRouterPairFeeTest is Test {
         assertEq(executedVenue, address(mockRouter));      // fallbackSwapRouter won
         assertEq(amountOut, 1000);
         assertEq(tokenOut.balanceOf(recipient), 1000);
+    }
+
+    function test_seedStablePairs_resolveToSeededTiers() public {
+        SeedStablePairs seed = new SeedStablePairs();
+        (address[] memory a, address[] memory b, uint24[] memory f) = seed.seedData();
+
+        router.setPairFees(a, b, f);
+
+        for (uint256 i = 0; i < a.length; i++) {
+            assertEq(router.resolvedFee(a[i], b[i]), f[i]);
+            // order-independence holds for the seeded pairs too
+            assertEq(router.resolvedFee(b[i], a[i]), f[i]);
+        }
     }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -16,10 +16,11 @@ contract PropAMMRouterPairFeeTest is Test {
     MockERC20 internal tokenOut;
 
     address internal owner = address(this);
-    address internal stranger = address(0xBEEF);
+    address internal stranger = address(0xBEEF); // used by setPairFee/setPairFees access-control tests in later tasks
     address internal recipient = address(0xCAFE);
 
     // Re-declared locally so vm.expectEmit can match the router's emit.
+    // Mirror of PropAMMRouter.PairFeeUpdated (added in a later task); kept in sync so vm.expectEmit matches.
     event PairFeeUpdated(address indexed tokenA, address indexed tokenB, uint24 oldFee, uint24 newFee);
 
     function setUp() public {

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -58,4 +58,40 @@ contract PropAMMRouterPairFeeTest is Test {
     function test_getPairFee_reversed_unset_returnsZero() public view {
         assertEq(router.getPairFee(address(tokenOut), address(tokenIn)), 0);
     }
+
+    function test_setPairFee_setsAndResolves() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        assertEq(router.resolvedFee(address(tokenIn), address(tokenOut)), 100);
+        assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 100);
+    }
+
+    function test_setPairFee_isOrderIndependent() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        assertEq(router.resolvedFee(address(tokenOut), address(tokenIn)), 100);
+        assertEq(router.getPairFee(address(tokenOut), address(tokenIn)), 100);
+    }
+
+    function test_setPairFee_clearWithZero() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        router.setPairFee(address(tokenIn), address(tokenOut), 0);
+        assertEq(router.resolvedFee(address(tokenIn), address(tokenOut)), 3000);
+        assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 0);
+    }
+
+    function test_setPairFee_revertsAboveMax() public {
+        vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.InvalidFallbackFee.selector, uint24(1_000_000)));
+        router.setPairFee(address(tokenIn), address(tokenOut), 1_000_000);
+    }
+
+    function test_setPairFee_emitsEvent() public {
+        vm.expectEmit(true, true, false, true, address(router));
+        emit PairFeeUpdated(address(tokenIn), address(tokenOut), 0, 100);
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+    }
+
+    function test_setPairFee_onlyOwner() public {
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -215,4 +215,20 @@ contract PropAMMRouterPairFeeTest is Test {
 
         assertEq(mockRouter.lastFee(), 3000);
     }
+
+    function test_swapV1_fallbackWins_usesResolvedFee() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        mockQuoter.setAmountOut(1000); // fallback quote wins the auction
+        mockRouter.setAmountOut(1000); // fallback execution delivers tokenOut
+        tokenIn.mint(address(this), 1000);
+        tokenIn.approve(address(router), 1000);
+
+        (uint256 amountOut, address executedVenue) =
+            router.swapV1(address(tokenIn), address(tokenOut), 1000, 900, recipient, block.timestamp + 1);
+
+        assertEq(mockRouter.lastFee(), 100);               // executed at the resolved per-pair tier
+        assertEq(executedVenue, address(mockRouter));      // fallbackSwapRouter won
+        assertEq(amountOut, 1000);
+        assertEq(tokenOut.balanceOf(recipient), 1000);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -20,7 +20,7 @@ contract PropAMMRouterPairFeeTest is Test {
     address internal recipient = address(0xCAFE);
 
     // Re-declared locally so vm.expectEmit can match the router's emit.
-    // Mirror of PropAMMRouter.PairFeeUpdated (added in a later task); kept in sync so vm.expectEmit matches.
+    // Mirror of PropAMMRouter.PairFeeUpdated (added in Task 3); kept in sync so vm.expectEmit matches.
     event PairFeeUpdated(address indexed tokenA, address indexed tokenB, uint24 oldFee, uint24 newFee);
 
     function setUp() public {
@@ -93,5 +93,12 @@ contract PropAMMRouterPairFeeTest is Test {
         vm.prank(stranger);
         vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
         router.setPairFee(address(tokenIn), address(tokenOut), 100);
+    }
+
+    function test_setPairFee_emitsEventWithPriorFeeAsOld() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 100);
+        vm.expectEmit(true, true, false, true, address(router));
+        emit PairFeeUpdated(address(tokenIn), address(tokenOut), 100, 500);
+        router.setPairFee(address(tokenIn), address(tokenOut), 500);
     }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -84,6 +84,12 @@ contract PropAMMRouterPairFeeTest is Test {
         router.setPairFee(address(tokenIn), address(tokenOut), 1_000_000);
     }
 
+    function test_setPairFee_acceptsMaxValidFee() public {
+        router.setPairFee(address(tokenIn), address(tokenOut), 999_999);
+        assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 999_999);
+        assertEq(router.resolvedFee(address(tokenIn), address(tokenOut)), 999_999);
+    }
+
     function test_setPairFee_emitsEvent() public {
         vm.expectEmit(true, true, false, true, address(router));
         emit PairFeeUpdated(address(tokenIn), address(tokenOut), 0, 100);

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -20,6 +20,12 @@ contract PropAMMRouterPairFeeTest is Test {
     address internal stranger = address(0xBEEF); // used by setPairFee/setPairFees access-control tests in later tasks
     address internal recipient = address(0xCAFE);
 
+    // Mainnet token addresses seeded as defaults by `initialize` (mirror of the
+    // contract's private constants; kept in sync so the seed assertions match).
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
     // Re-declared locally so vm.expectEmit can match the router's emit.
     // Mirror of PropAMMRouter.PairFeeUpdated (added in Task 3); kept in sync so vm.expectEmit matches.
     event PairFeeUpdated(address indexed tokenA, address indexed tokenB, uint24 oldFee, uint24 newFee);
@@ -42,6 +48,23 @@ contract PropAMMRouterPairFeeTest is Test {
         assertEq(router.fallbackFee(), 3000);
         assertEq(router.fallbackSwapRouter(), address(mockRouter));
         assertEq(router.fallbackQuoter(), address(mockQuoter));
+    }
+
+    function test_initialize_seedsDefaultPairFees() public view {
+        // A from-scratch deploy (the proxy in setUp) is configured with the deep
+        // mainnet tiers without any owner action after init.
+        assertEq(router.getPairFee(USDT, USDC), 100);
+        assertEq(router.getPairFee(USDT, WETH), 500);
+        assertEq(router.getPairFee(USDC, WETH), 500);
+
+        assertEq(router.resolvedFee(USDT, USDC), 100);
+        assertEq(router.resolvedFee(USDT, WETH), 500);
+        assertEq(router.resolvedFee(USDC, WETH), 500);
+
+        // Order-independence holds for the seeded pairs too.
+        assertEq(router.resolvedFee(USDC, USDT), 100);
+        assertEq(router.resolvedFee(WETH, USDT), 500);
+        assertEq(router.resolvedFee(WETH, USDC), 500);
     }
 
     function test_resolvedFee_unset_returnsGlobalDefault() public view {

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -155,4 +155,18 @@ contract PropAMMRouterPairFeeTest is Test {
         vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
         router.setPairFees(a, b, f);
     }
+
+    function test_setPairFees_midBatchInvalidFeeRevertsAll() public {
+        address[] memory a = new address[](2);
+        address[] memory b = new address[](2);
+        uint24[] memory f = new uint24[](2);
+        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;       // valid
+        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 1_000_000; // invalid
+
+        vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.InvalidFallbackFee.selector, uint24(1_000_000)));
+        router.setPairFees(a, b, f);
+
+        // entry 0 must NOT have been committed (whole batch rolled back)
+        assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 0);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -101,4 +101,58 @@ contract PropAMMRouterPairFeeTest is Test {
         emit PairFeeUpdated(address(tokenIn), address(tokenOut), 100, 500);
         router.setPairFee(address(tokenIn), address(tokenOut), 500);
     }
+
+    function test_setPairFees_batchSets() public {
+        address[] memory a = new address[](2);
+        address[] memory b = new address[](2);
+        uint24[] memory f = new uint24[](2);
+        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;
+        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 500;
+
+        router.setPairFees(a, b, f);
+
+        assertEq(router.resolvedFee(address(tokenIn), address(tokenOut)), 100);
+        assertEq(router.resolvedFee(address(tokenOut), address(0x1234)), 500);
+    }
+
+    function test_setPairFees_emitsPerPair() public {
+        address[] memory a = new address[](2);
+        address[] memory b = new address[](2);
+        uint24[] memory f = new uint24[](2);
+        a[0] = address(tokenIn);  b[0] = address(tokenOut); f[0] = 100;
+        a[1] = address(tokenOut); b[1] = address(0x1234);   f[1] = 500;
+
+        vm.expectEmit(true, true, false, true, address(router));
+        emit PairFeeUpdated(address(tokenIn), address(tokenOut), 0, 100);
+        vm.expectEmit(true, true, false, true, address(router));
+        emit PairFeeUpdated(address(tokenOut), address(0x1234), 0, 500);
+
+        router.setPairFees(a, b, f);
+    }
+
+    function test_setPairFees_lengthMismatchReverts() public {
+        address[] memory a = new address[](2);
+        address[] memory b = new address[](1);
+        uint24[] memory f = new uint24[](2);
+        vm.expectRevert(PropAMMRouter.ArrayLengthMismatch.selector);
+        router.setPairFees(a, b, f);
+    }
+
+    function test_setPairFees_invalidFeeInSlotReverts() public {
+        address[] memory a = new address[](1);
+        address[] memory b = new address[](1);
+        uint24[] memory f = new uint24[](1);
+        a[0] = address(tokenIn); b[0] = address(tokenOut); f[0] = 1_000_000;
+        vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.InvalidFallbackFee.selector, uint24(1_000_000)));
+        router.setPairFees(a, b, f);
+    }
+
+    function test_setPairFees_onlyOwner() public {
+        address[] memory a = new address[](0);
+        address[] memory b = new address[](0);
+        uint24[] memory f = new uint24[](0);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", stranger));
+        router.setPairFees(a, b, f);
+    }
 }

--- a/test/PropAMMRouterPairFee.t.sol
+++ b/test/PropAMMRouterPairFee.t.sol
@@ -50,4 +50,12 @@ contract PropAMMRouterPairFeeTest is Test {
     function test_getPairFee_unset_returnsZero() public view {
         assertEq(router.getPairFee(address(tokenIn), address(tokenOut)), 0);
     }
+
+    function test_resolvedFee_reversed_unset_returnsGlobalDefault() public view {
+        assertEq(router.resolvedFee(address(tokenOut), address(tokenIn)), 3000);
+    }
+
+    function test_getPairFee_reversed_unset_returnsZero() public view {
+        assertEq(router.getPairFee(address(tokenOut), address(tokenIn)), 0);
+    }
 }

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/mocks/MockQuoterV2.sol
+++ b/test/mocks/MockQuoterV2.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IQuoterV2} from "@uniswap/v3-periphery/contracts/interfaces/IQuoterV2.sol";
+
+/// @notice Minimal QuoterV2 stand-in. Records the fee tier it was called with
+/// and returns a configurable amountOut.
+contract MockQuoterV2 {
+    uint24 public lastFee;
+    uint256 public amountOutToReturn;
+
+    function setAmountOut(uint256 amountOut_) external {
+        amountOutToReturn = amountOut_;
+    }
+
+    function quoteExactInputSingle(IQuoterV2.QuoteExactInputSingleParams memory params)
+        external
+        returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+    {
+        lastFee = params.fee;
+        return (amountOutToReturn, 0, 0, 0);
+    }
+}

--- a/test/mocks/MockQuoterV2.sol
+++ b/test/mocks/MockQuoterV2.sol
@@ -7,7 +7,7 @@ import {IQuoterV2} from "@uniswap/v3-periphery/contracts/interfaces/IQuoterV2.so
 /// and returns a configurable amountOut.
 contract MockQuoterV2 {
     uint24 public lastFee;
-    uint256 public amountOutToReturn;
+    uint256 public amountOutToReturn; // defaults to 0; call setAmountOut(...) before swap/quote tests
 
     function setAmountOut(uint256 amountOut_) external {
         amountOutToReturn = amountOut_;

--- a/test/mocks/MockSwapRouter02.sol
+++ b/test/mocks/MockSwapRouter02.sol
@@ -8,12 +8,17 @@ import {MockERC20} from "./MockERC20.sol";
 /// with and delivers a configurable amountOut of tokenOut to the recipient.
 contract MockSwapRouter02 {
     uint24 public lastFee;
-    uint256 public amountOutToReturn;
+    uint256 public amountOutToReturn; // defaults to 0; call setAmountOut(...) before swap/quote tests
 
     function setAmountOut(uint256 amountOut_) external {
         amountOutToReturn = amountOut_;
     }
 
+    /// @dev Deliberate deviation from the real SwapRouter02: this mock does NOT
+    /// pull `tokenIn` from the caller; it only delivers `tokenOut`. As a result
+    /// the router retains the `tokenIn` it pulled after a swap in tests. That is
+    /// intentional for these fee-wiring tests and does not affect the recipient
+    /// balance-delta assertions (which measure `tokenOut` delivered).
     function exactInputSingle(IV3SwapRouter.ExactInputSingleParams calldata params)
         external
         payable

--- a/test/mocks/MockSwapRouter02.sol
+++ b/test/mocks/MockSwapRouter02.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IV3SwapRouter} from "@uniswap/swap-router-contracts/contracts/interfaces/IV3SwapRouter.sol";
+import {MockERC20} from "./MockERC20.sol";
+
+/// @notice Minimal SwapRouter02 stand-in. Records the fee tier it was called
+/// with and delivers a configurable amountOut of tokenOut to the recipient.
+contract MockSwapRouter02 {
+    uint24 public lastFee;
+    uint256 public amountOutToReturn;
+
+    function setAmountOut(uint256 amountOut_) external {
+        amountOutToReturn = amountOut_;
+    }
+
+    function exactInputSingle(IV3SwapRouter.ExactInputSingleParams calldata params)
+        external
+        payable
+        returns (uint256 amountOut)
+    {
+        lastFee = params.fee;
+        amountOut = amountOutToReturn;
+        MockERC20(params.tokenOut).mint(params.recipient, amountOut);
+        return amountOut;
+    }
+}


### PR DESCRIPTION
**Problem**. The router's Uniswap fallback venue routed every pair through a single hardcoded 3000 (0.30%) fee tier. That's wrong for pairs that have deeper liquidity in another tier. For example: stablecoin pairs (USDC/DAI, USDC/USDT) trade in the 500/100 tiers, so forcing them through 0.30% gives worse quotes/execution.

**Proposed Solution:** Make the fallback fee tier configurable per token pair, with a global default:

  - Storage: _pairFee maps an order-independent _pairKey(tokenA, tokenB) → uint24 fee. A stored 0 means "unset." The existing global tier is retained as fallbackFee (defaults to 3000).
  - Resolver: _resolveFee(tokenIn, tokenOut) returns the per-pair override if set, otherwise fallbackFee. This single resolver is wired into all three Uniswap fallback read/write sites.
  - Admin API (owner-only): setPairFee(a, b, fee) and the batch setPairFees(a[], b[], fees[]) (which reverts atomically with ArrayLengthMismatch on uneven arrays); setting fee = 0 clears an override back to the fallback. Each change emits PairFeeUpdated(tokenA, tokenB, oldFee, newFee).
  - Views: getPairFee(a, b) returns the raw stored override (0 if unset); resolvedFee(a, b) returns what the router would actually use.
  - Ops: a new owner-run SeedStablePairs script pre-populates common stable pairs (defaulting DAI/USDT to the 500 tier).
  
  