### PR TITLE
add foundry tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ forge clean && forge script scripts/Deploy.s.sol \
     --private-key $DEPLOYER_KEY
 ```
 
+### Running the fork tests
+
+`test/PropAMMRouterForkTests.t.sol` tests the `PropAMMRouter` against a Foundry fork of mainnet, pinned to the block Titan publishes per request. Each test applies the per-venue Titan stateOverride via `vm.store` / `vm.deal` / `vm.setNonceUnsafe`, then runs a USDC → WETH swap and asserts the delivered `amountOut` is at least the venue's quoted `amountOut`.
+
+Driven by `test/run_fork_tests.sh`, which:
+
+1. Queries Titan for the latest per-PMM overrides, flattens them into JSON arrays Foundry's `parseJson` can decode, and exports them as env vars.
+2. Forks mainnet at `min(titanBlock, rpcHead)` (the local RPC may lag Titan by 1-2 blocks; `vm.createSelectFork` rejects future blocks).
+3. Runs `forge test --match-contract PropAMMRouterForkTests --gas-report -vvvv`.
+
+**Required env vars:**
+
+- `ETH_RPC_URL`: mainnet RPC endpoint
+- `TITAN_URL` (optional): defaults to `https://us.rpc.titanbuilder.xyz`.
+
+Run with:
+
+```bash
+export ETH_RPC_URL=<your mainnet RPC>
+./test/run_fork_tests.sh
+```
+
+You can append any `forge test` flags (e.g. `--match-test test_swapViaVenueV1Kipseli`) — they're forwarded verbatim to the underlying `forge test` invocation.
+
 ### Quoting with Titan state overrides
 
 The proprietary AMMs maintain off-chain liquidity that is not reflected by mainnet state, so a plain `eth_call` to `PropAMMRouter.quoteV1` against the anvil fork only sees stale liquidity. To get accurate quotes, Titan exposes the JSON-RPC method `titan_getPammStateOverrides`, whose result is passed as the third parameter of `eth_call`.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -166,12 +166,9 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
-    /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with
-    /// `swapV1`, the fallback remains as the transparent safety net inside `_coreSwap`.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and `QuoteBelowMinimum` 
-    /// before pulling funds when the best quote across `venues` is under `amountOutMin`; 
-    /// quotes are advisory, so `_coreSwap` re-checks `amountOutMin` against the delivered
-    /// balance delta.
+    /// `_pickBestVenueFrom`, and if any venue returns a quote that is at least
+    /// `amountOutMin`, then attempts to swap via that venue. Otherwise, it defaults
+    /// to swapping via Uniswap V3
     function swapViaSelectedVenuesV1(
         address[] calldata venues,
         address tokenIn,
@@ -183,10 +180,15 @@ contract PropAMMRouter is
     ) public whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
         // Fail fast before the on-chain requote; `_coreSwap` re-checks deadline.
         require(block.timestamp <= deadline, Expired());
+
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
-        // Reject when none of the selected venues could be priced (venue stays address(0)).
-        require(venue != address(0), NoQuotesAvailable());
-        require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
+
+        // Quote step "failed" (none of `venues` priced, or the best is below the
+        // minimum): route to the fallback venue, which `_coreSwap` runs directly.
+        if (venue == address(0) || bestQuote < amountOutMin) {
+            venue = fallbackSwapRouter;
+        }
+
         return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
     }
 

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -183,8 +183,8 @@ contract PropAMMRouter is
 
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
 
-        // Quote step "failed" (none of `venues` priced, or the best is below the
-        // minimum): route to the fallback venue, which `_coreSwap` runs directly.
+        // If no quotes available, or the best quote is below the minimum,
+        // route to the fallback venue, which `_coreSwap` runs directly.
         if (venue == address(0) || bestQuote < amountOutMin) {
             venue = fallbackSwapRouter;
         }

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -81,8 +81,8 @@ interface IPropAMMRouter {
     /// venues. An on-chain requote across `venues` selects the best.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Venues that revert while quoting (including non-whitelisted
-    /// addresses) are skipped. The whole requote-and-swap over `venues` falls
-    /// back to the public venue if it fails for any reason.
+    /// addresses) are skipped. The public-venue fallback still applies as the
+    /// transparent safety net if the chosen proprietary venue fails to fill.
     /// Reverts only if even the public-venue fallback cannot deliver `amountOutMin`.
     /// @param venues The venues to consider — a subset of the available venues.
     /// @param tokenIn The token being sold.

--- a/src/interfaces/IPropAMMRouter.sol
+++ b/src/interfaces/IPropAMMRouter.sol
@@ -81,12 +81,9 @@ interface IPropAMMRouter {
     /// venues. An on-chain requote across `venues` selects the best.
     /// @dev The caller must approve this contract for at least `amountIn` of
     /// `tokenIn`. Venues that revert while quoting (including non-whitelisted
-    /// addresses) are skipped. The public-venue fallback still applies as the
-    /// transparent safety net if the chosen proprietary venue fails to fill.
-    /// Reverts `NoQuotesAvailable` if none of `venues` can be priced, and
-    /// `QuoteBelowMinimum` before pulling funds if the best quote across `venues`
-    /// is below `amountOutMin`, and re-checks `amountOutMin` against the
-    /// delivered balance delta after execution.
+    /// addresses) are skipped. The whole requote-and-swap over `venues` falls
+    /// back to the public venue if it fails for any reason.
+    /// Reverts only if even the public-venue fallback cannot deliver `amountOutMin`.
     /// @param venues The venues to consider — a subset of the available venues.
     /// @param tokenIn The token being sold.
     /// @param tokenOut The token being bought.

--- a/test/PropAMMRouterForkTests.t.sol
+++ b/test/PropAMMRouterForkTests.t.sol
@@ -132,18 +132,18 @@ contract PropAMMRouterForkTests is Test {
         // in case a sibling test (e.g. test_swapV1ViaBebop) `vm.roll`ed
         // earlier and Foundry didn't fully revert it across the shared fork.
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         _runSwapV1("fermi", FERMI_ROUTER);
     }
 
     function test_swapV1ViaKipseli() public {
         vm.roll(titanBlock);
-        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _overrideState(kipseliStorage, kipseliBalances, kipseliNonces);
         _runSwapV1("kipseli", KIPSELI_PAMM);
     }
 
     function test_swapV1ViaBebop() public {
-        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        _overrideState(bebopStorage, bebopBalances, bebopNonces);
         // Bebop only accepts a swap at the exact block its latest price was
         // published for, which may trail Titan's reported block. Roll to that
         // block so the override is accepted.
@@ -163,18 +163,18 @@ contract PropAMMRouterForkTests is Test {
 
     function test_swapViaVenueV1Fermi() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         _runSwapViaVenueV1(FERMI_ROUTER);
     }
 
     function test_swapViaVenueV1Kipseli() public {
         vm.roll(titanBlock);
-        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _overrideState(kipseliStorage, kipseliBalances, kipseliNonces);
         _runSwapViaVenueV1(KIPSELI_PAMM);
     }
 
     function test_swapViaVenueV1Bebop() public {
-        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        _overrideState(bebopStorage, bebopBalances, bebopNonces);
         uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
         vm.roll(bebopFresh);
         _runSwapViaVenueV1(BEBOP_ROUTER);
@@ -208,18 +208,18 @@ contract PropAMMRouterForkTests is Test {
 
     function test_swapViaSelectedVenuesV1Fermi() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         _runSwapViaSelectedVenuesV1("fermi", _venues(FERMI_ROUTER));
     }
 
     function test_swapViaSelectedVenuesV1Kipseli() public {
         vm.roll(titanBlock);
-        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _overrideState(kipseliStorage, kipseliBalances, kipseliNonces);
         _runSwapViaSelectedVenuesV1("kipseli", _venues(KIPSELI_PAMM));
     }
 
     function test_swapViaSelectedVenuesV1Bebop() public {
-        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        _overrideState(bebopStorage, bebopBalances, bebopNonces);
         uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
         vm.roll(bebopFresh);
         _runSwapViaSelectedVenuesV1("bebop", _venues(BEBOP_ROUTER));
@@ -230,7 +230,7 @@ contract PropAMMRouterForkTests is Test {
     /// skipped, so Fermi wins the subset selection.
     function test_swapViaSelectedVenuesV1PicksBestAmongSubset() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         address[] memory venues = new address[](3);
         venues[0] = FERMI_ROUTER;
         venues[1] = KIPSELI_PAMM;
@@ -252,7 +252,7 @@ contract PropAMMRouterForkTests is Test {
 
     function test_quoteV1() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
 
         (uint256 bestQuote, address venue) = router.quoteV1(
             USDC,
@@ -276,7 +276,7 @@ contract PropAMMRouterForkTests is Test {
 
     function test_quoteVenueV1Fermi() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         assertGt(
             router.quoteVenueV1(FERMI_ROUTER, USDC, WETH, AMOUNT_IN),
             0,
@@ -305,18 +305,18 @@ contract PropAMMRouterForkTests is Test {
 
     function test_quoteSelectedVenuesV1Fermi() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         _assertSelectedQuoteSingle(FERMI_ROUTER);
     }
 
     function test_quoteSelectedVenuesV1Kipseli() public {
         vm.roll(titanBlock);
-        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _overrideState(kipseliStorage, kipseliBalances, kipseliNonces);
         _assertSelectedQuoteSingle(KIPSELI_PAMM);
     }
 
     function test_quoteSelectedVenuesV1Bebop() public {
-        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        _overrideState(bebopStorage, bebopBalances, bebopNonces);
         uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
         vm.roll(bebopFresh);
         _assertSelectedQuoteSingle(BEBOP_ROUTER);
@@ -335,7 +335,7 @@ contract PropAMMRouterForkTests is Test {
     /// remaining valid venue still wins.
     function test_quoteSelectedVenuesV1SkipsUnknownAddress() public {
         vm.roll(titanBlock);
-        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _overrideState(fermiStorage, fermiBalances, fermiNonces);
         address[] memory venues = new address[](2);
         venues[0] = makeAddr("not-a-venue");
         venues[1] = FERMI_ROUTER;
@@ -385,7 +385,7 @@ contract PropAMMRouterForkTests is Test {
     /// (`vm.store`), per-account balances (`vm.deal`), per-account nonces
     /// (`vm.setNonceUnsafe`, which doesn't reject lower-than-current values the
     /// way `vm.setNonce` does).
-    function _applyAll(
+    function _overrideState(
         StorageOverride[] storage storageList,
         AccountValue[] storage balanceList,
         AccountValue[] storage nonceList

--- a/test/PropAMMRouterForkTests.t.sol
+++ b/test/PropAMMRouterForkTests.t.sol
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {
+    ERC1967Proxy
+} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+import {IPropAMMRouter} from "../src/interfaces/IPropAMMRouter.sol";
+import {FERMI_ROUTER} from "../src/interfaces/IFermiSwapper.sol";
+import {BEBOP_ROUTER} from "../src/interfaces/IBebopRouter.sol";
+import {KIPSELI_PAMM} from "../src/interfaces/IKipseliPAMM.sol";
+
+/// @title PropAMMRouterForkTests
+/// @notice Fork-test rig exercising the `IPropAMMRouter` interface against a
+/// mainnet fork: the swap entrypoints (`swapV1`, `swapViaVenueV1`,
+/// `swapViaSelectedVenuesV1`) and the quote views (`quoteV1`, `quoteVenueV1`,
+/// `quoteSelectedVenuesV1`).
+///
+/// `setUp()` forks mainnet at the Titan-published block, deploys a fresh
+/// PropAMMRouter (impl + UUPS proxy), funds the taker with USDC, and parses
+/// three env-var-provided per-PMM storage-override arrays.
+///
+/// Each test applies one venue's overrides via `vm.store`, sends the swap
+/// through the chosen entrypoint, and logs the gas delta. Because the whole
+/// test runs in a single transaction context, `block.number` stays at the
+/// Titan block — no per-tx drift like in the live-Anvil flow.
+///
+/// Venues are identified by router address. The public-venue fallback is the
+/// `fallbackSwapRouter` (Uniswap V3 SwapRouter02); it is a nameable venue
+/// (`quoteVenueV1` / `swapViaVenueV1` accept it) and is also the automatic
+/// safety net. So a swap's `executedVenue` is either the proprietary venue
+/// under test or `SWAP_ROUTER_02`.
+///
+/// Driven by `scripts/run_fork_tests.sh`, which queries Titan, flattens its
+/// nested override blob into `[{account, slot, value}, …]` per venue, and
+/// exports the env vars before invoking `forge test`.
+contract PropAMMRouterForkTests is Test {
+    /// @dev Mainnet USDC (FiatTokenV2_2). Balance slot is 9 (packed with
+    /// the high-bit blacklist flag); allowance slot is 10.
+    address constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    /// @dev Uniswap V3 SwapRouter02 + QuoterV2 — same fallback wiring as
+    /// `scripts/Deploy.s.sol`. `SWAP_ROUTER_02` doubles as the venue address
+    /// the router reports (and that callers may name) for the public-venue
+    /// fallback.
+    address constant SWAP_ROUTER_02 =
+        0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45;
+    address constant QUOTER_V2 = 0x61fFE014bA17989E743c5F6cB21bF9697530B21e;
+
+    uint256 constant USDC_BALANCES_SLOT = 9;
+    uint256 constant USDC_ALLOWANCES_SLOT = 10;
+
+    uint256 constant AMOUNT_IN = 100e6; // 100 USDC
+
+    /// @dev Flat shapes the bash wrapper emits per venue. Field names are
+    /// alphabetical, matching Foundry's `parseJson` decoding order.
+    struct StorageOverride {
+        address account;
+        bytes32 slot;
+        bytes32 value;
+    }
+
+    /// @dev Same shape used for `balance` and `nonce` overrides — both
+    /// are per-account scalars (no slot key needed).
+    struct AccountValue {
+        address account;
+        bytes32 value;
+    }
+
+    PropAMMRouter router;
+    address taker;
+
+    StorageOverride[] fermiStorage;
+    AccountValue[] fermiBalances;
+    AccountValue[] fermiNonces;
+
+    StorageOverride[] kipseliStorage;
+    AccountValue[] kipseliBalances;
+    AccountValue[] kipseliNonces;
+
+    StorageOverride[] bebopStorage;
+    AccountValue[] bebopBalances;
+    AccountValue[] bebopNonces;
+
+    uint256 titanBlock;
+
+    function setUp() public {
+        string memory rpc = vm.envString("ETH_RPC_URL");
+        titanBlock = vm.envUint("TITAN_BLOCK");
+
+        vm.createSelectFork(rpc, titanBlock);
+
+        _stashStorage(fermiStorage, vm.envString("TITAN_FERMI_STORAGE"));
+        _stashAccounts(fermiBalances, vm.envString("TITAN_FERMI_BALANCES"));
+        _stashAccounts(fermiNonces, vm.envString("TITAN_FERMI_NONCES"));
+
+        _stashStorage(kipseliStorage, vm.envString("TITAN_KIPSELI_STORAGE"));
+        _stashAccounts(kipseliBalances, vm.envString("TITAN_KIPSELI_BALANCES"));
+        _stashAccounts(kipseliNonces, vm.envString("TITAN_KIPSELI_NONCES"));
+
+        _stashStorage(bebopStorage, vm.envString("TITAN_BEBOP_STORAGE"));
+        _stashAccounts(bebopBalances, vm.envString("TITAN_BEBOP_BALANCES"));
+        _stashAccounts(bebopNonces, vm.envString("TITAN_BEBOP_NONCES"));
+
+        taker = makeAddr("taker");
+
+        PropAMMRouter impl = new PropAMMRouter();
+        bytes memory init = abi.encodeCall(
+            PropAMMRouter.initialize,
+            (SWAP_ROUTER_02, QUOTER_V2, address(this))
+        );
+        router = PropAMMRouter(
+            payable(address(new ERC1967Proxy(address(impl), init)))
+        );
+
+        // Fund the taker with 1M USDC (well above the worst-case test spend).
+        _fundTakerUSDC(1_000_000 * 1e6);
+        _setMaxAllowance(USDC, taker, address(router));
+        // Give the taker ETH for the tx-gas accounting that `vm.prank` will
+        // hand to the EVM — Foundry's default would otherwise leave it at 0.
+        vm.deal(taker, 10 ether);
+    }
+
+    // -------------------------------------------------------------
+    // swapV1 — auto-selects the best venue across PMMs + fallback
+    // -------------------------------------------------------------
+
+    function test_swapV1ViaFermi() public {
+        // Defensive: pin block.number back to the Titan-published block
+        // in case a sibling test (e.g. test_swapV1ViaBebop) `vm.roll`ed
+        // earlier and Foundry didn't fully revert it across the shared fork.
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _runSwapV1("fermi", FERMI_ROUTER);
+    }
+
+    function test_swapV1ViaKipseli() public {
+        vm.roll(titanBlock);
+        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _runSwapV1("kipseli", KIPSELI_PAMM);
+    }
+
+    function test_swapV1ViaBebop() public {
+        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        // Bebop only accepts a swap at the exact block its latest price was
+        // published for, which may trail Titan's reported block. Roll to that
+        // block so the override is accepted.
+        uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
+        vm.roll(bebopFresh);
+        _runSwapV1("bebop", BEBOP_ROUTER);
+    }
+
+    function test_swapV1ViaFallback() public {
+        // No PMM overrides applied, so the public-venue fallback wins.
+        _runSwapV1("fallback", SWAP_ROUTER_02);
+    }
+
+    // -------------------------------------------------------------
+    // swapViaVenueV1 — caller pins a single venue
+    // -------------------------------------------------------------
+
+    function test_swapViaVenueV1Fermi() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _runSwapViaVenueV1(FERMI_ROUTER);
+    }
+
+    function test_swapViaVenueV1Kipseli() public {
+        vm.roll(titanBlock);
+        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _runSwapViaVenueV1(KIPSELI_PAMM);
+    }
+
+    function test_swapViaVenueV1Bebop() public {
+        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
+        vm.roll(bebopFresh);
+        _runSwapViaVenueV1(BEBOP_ROUTER);
+    }
+
+    /// @dev Naming the fallback address routes directly to the public venue.
+    function test_swapViaVenueV1Fallback() public {
+        _runSwapViaVenueV1(SWAP_ROUTER_02);
+    }
+
+    /// @dev A non-whitelisted, non-fallback address must revert `UnknownVenue`
+    /// before any funds move.
+    function test_swapViaVenueV1RevertsForUnknownVenue() public {
+        uint256 deadline = block.timestamp + 120;
+        vm.prank(taker);
+        vm.expectRevert(PropAMMRouter.UnknownVenue.selector);
+        router.swapViaVenueV1(
+            makeAddr("not-a-venue"),
+            USDC,
+            WETH,
+            AMOUNT_IN,
+            0,
+            taker,
+            deadline
+        );
+    }
+
+    // -------------------------------------------------------------
+    // swapViaSelectedVenuesV1 — best of a caller-supplied venue subset
+    // -------------------------------------------------------------
+
+    function test_swapViaSelectedVenuesV1Fermi() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _runSwapViaSelectedVenuesV1("fermi", _venues(FERMI_ROUTER));
+    }
+
+    function test_swapViaSelectedVenuesV1Kipseli() public {
+        vm.roll(titanBlock);
+        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _runSwapViaSelectedVenuesV1("kipseli", _venues(KIPSELI_PAMM));
+    }
+
+    function test_swapViaSelectedVenuesV1Bebop() public {
+        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
+        vm.roll(bebopFresh);
+        _runSwapViaSelectedVenuesV1("bebop", _venues(BEBOP_ROUTER));
+    }
+
+    /// @dev With only Fermi's override applied, passing the full PMM set must
+    /// still pick Fermi: the un-overridden Kipseli/Bebop quotes revert and are
+    /// skipped, so Fermi wins the subset selection.
+    function test_swapViaSelectedVenuesV1PicksBestAmongSubset() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        address[] memory venues = new address[](3);
+        venues[0] = FERMI_ROUTER;
+        venues[1] = KIPSELI_PAMM;
+        venues[2] = BEBOP_ROUTER;
+
+        (, address quotedVenue) = router.quoteSelectedVenuesV1(
+            venues,
+            USDC,
+            WETH,
+            AMOUNT_IN
+        );
+        assertEq(quotedVenue, FERMI_ROUTER, "expected Fermi to win the subset");
+        _runSwapViaSelectedVenuesV1("subset", venues);
+    }
+
+    // -------------------------------------------------------------
+    // quoteV1 — best quote across all venues
+    // -------------------------------------------------------------
+
+    function test_quoteV1() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+
+        (uint256 bestQuote, address venue) = router.quoteV1(
+            USDC,
+            WETH,
+            AMOUNT_IN
+        );
+
+        assertGt(bestQuote, 0, "quoteV1 returned zero");
+        assertTrue(_isKnownVenue(venue), "quoteV1 returned an unknown venue");
+        // The reported best must match that venue's own single-venue quote.
+        assertEq(
+            bestQuote,
+            router.quoteVenueV1(venue, USDC, WETH, AMOUNT_IN),
+            "quoteV1 best != quoteVenueV1(best venue)"
+        );
+    }
+
+    // -------------------------------------------------------------
+    // quoteVenueV1 — single venue by address
+    // -------------------------------------------------------------
+
+    function test_quoteVenueV1Fermi() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        assertGt(
+            router.quoteVenueV1(FERMI_ROUTER, USDC, WETH, AMOUNT_IN),
+            0,
+            "fermi quote is zero"
+        );
+    }
+
+    /// @dev The fallback (Uniswap) is a nameable venue and reads live on-chain
+    /// pool state, so it needs no Titan override.
+    function test_quoteVenueV1Fallback() public {
+        assertGt(
+            router.quoteVenueV1(SWAP_ROUTER_02, USDC, WETH, AMOUNT_IN),
+            0,
+            "fallback quote is zero"
+        );
+    }
+
+    function test_quoteVenueV1RevertsForUnknownVenue() public {
+        vm.expectRevert(PropAMMRouter.UnknownVenue.selector);
+        router.quoteVenueV1(makeAddr("not-a-venue"), USDC, WETH, AMOUNT_IN);
+    }
+
+    // -------------------------------------------------------------
+    // quoteSelectedVenuesV1 — best quote across a caller-supplied subset
+    // -------------------------------------------------------------
+
+    function test_quoteSelectedVenuesV1Fermi() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        _assertSelectedQuoteSingle(FERMI_ROUTER);
+    }
+
+    function test_quoteSelectedVenuesV1Kipseli() public {
+        vm.roll(titanBlock);
+        _applyAll(kipseliStorage, kipseliBalances, kipseliNonces);
+        _assertSelectedQuoteSingle(KIPSELI_PAMM);
+    }
+
+    function test_quoteSelectedVenuesV1Bebop() public {
+        _applyAll(bebopStorage, bebopBalances, bebopNonces);
+        uint256 bebopFresh = vm.envUint("BEBOP_FRESH_BLOCK");
+        vm.roll(bebopFresh);
+        _assertSelectedQuoteSingle(BEBOP_ROUTER);
+    }
+
+    /// @dev An empty `venues` array yields no positive quote and must revert
+    /// `NoQuotesAvailable`.
+    function test_quoteSelectedVenuesV1EmptyReverts() public {
+        address[] memory venues = new address[](0);
+        vm.expectRevert(PropAMMRouter.NoQuotesAvailable.selector);
+        router.quoteSelectedVenuesV1(venues, USDC, WETH, AMOUNT_IN);
+    }
+
+    /// @dev A non-whitelisted address in the subset is skipped (its
+    /// `quoteVenueV1` reverts `UnknownVenue`, caught by the loop), so the
+    /// remaining valid venue still wins.
+    function test_quoteSelectedVenuesV1SkipsUnknownAddress() public {
+        vm.roll(titanBlock);
+        _applyAll(fermiStorage, fermiBalances, fermiNonces);
+        address[] memory venues = new address[](2);
+        venues[0] = makeAddr("not-a-venue");
+        venues[1] = FERMI_ROUTER;
+
+        (uint256 amountOut, address venue) = router.quoteSelectedVenuesV1(
+            venues,
+            USDC,
+            WETH,
+            AMOUNT_IN
+        );
+        assertEq(venue, FERMI_ROUTER, "unknown address should be skipped");
+        assertGt(amountOut, 0, "no quote returned");
+    }
+
+    // -------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------
+
+    /// @dev Parses the flat `[{account, slot, value}, …]` env JSON and pushes
+    /// each row into the storage array. Storage arrays can't be assigned
+    /// wholesale so we copy element by element.
+    function _stashStorage(
+        StorageOverride[] storage dst,
+        string memory json
+    ) internal {
+        bytes memory raw = vm.parseJson(json);
+        StorageOverride[] memory list = abi.decode(raw, (StorageOverride[]));
+        for (uint256 i = 0; i < list.length; i++) {
+            dst.push(list[i]);
+        }
+    }
+
+    /// @dev Same idea for the `{account, value}` shape used by balance and
+    /// nonce overrides.
+    function _stashAccounts(
+        AccountValue[] storage dst,
+        string memory json
+    ) internal {
+        bytes memory raw = vm.parseJson(json);
+        AccountValue[] memory list = abi.decode(raw, (AccountValue[]));
+        for (uint256 i = 0; i < list.length; i++) {
+            dst.push(list[i]);
+        }
+    }
+
+    /// @dev Apply one venue's full override package: storage slots
+    /// (`vm.store`), per-account balances (`vm.deal`), per-account nonces
+    /// (`vm.setNonceUnsafe`, which doesn't reject lower-than-current values the
+    /// way `vm.setNonce` does).
+    function _applyAll(
+        StorageOverride[] storage storageList,
+        AccountValue[] storage balanceList,
+        AccountValue[] storage nonceList
+    ) internal {
+        for (uint256 i = 0; i < storageList.length; i++) {
+            vm.store(
+                storageList[i].account,
+                storageList[i].slot,
+                storageList[i].value
+            );
+        }
+        for (uint256 i = 0; i < balanceList.length; i++) {
+            vm.deal(balanceList[i].account, uint256(balanceList[i].value));
+        }
+        for (uint256 i = 0; i < nonceList.length; i++) {
+            vm.setNonceUnsafe(
+                nonceList[i].account,
+                uint64(uint256(nonceList[i].value))
+            );
+        }
+    }
+
+    function _fundTakerUSDC(uint256 amount) internal {
+        bytes32 slot = keccak256(abi.encode(taker, USDC_BALANCES_SLOT));
+        // USDC packs the blacklisted flag in the top bit. Writing a plain
+        // uint256 with the high bit clear leaves the taker un-blacklisted and
+        // sets the balance to `amount`.
+        vm.store(USDC, slot, bytes32(amount));
+
+        // Sanity-check via the public balanceOf to catch storage-layout
+        // mistakes early.
+        assertEq(IERC20(USDC).balanceOf(taker), amount, "USDC fund failed");
+    }
+
+    function _setMaxAllowance(
+        address token,
+        address owner,
+        address spender
+    ) internal {
+        bytes32 inner = keccak256(abi.encode(owner, USDC_ALLOWANCES_SLOT));
+        bytes32 slot = keccak256(abi.encode(spender, inner));
+        vm.store(token, slot, bytes32(type(uint256).max));
+
+        assertEq(
+            IERC20(token).allowance(owner, spender),
+            type(uint256).max,
+            "allowance set failed"
+        );
+    }
+
+    /// @dev Builds a single-element venue array.
+    function _venues(address venue) internal pure returns (address[] memory) {
+        address[] memory venues = new address[](1);
+        venues[0] = venue;
+        return venues;
+    }
+
+    /// @dev True for any address a caller may name as a venue: the three
+    /// proprietary AMMs or the public-venue fallback.
+    function _isKnownVenue(address venue) internal pure returns (bool) {
+        return
+            venue == FERMI_ROUTER ||
+            venue == KIPSELI_PAMM ||
+            venue == BEBOP_ROUTER ||
+            venue == SWAP_ROUTER_02;
+    }
+
+    function _runSwapV1(string memory label, address expectedVenue) internal {
+        // `quoteVenueV1` prices every nameable venue, including the fallback.
+        uint256 amountOutMin = router.quoteVenueV1(
+            expectedVenue,
+            USDC,
+            WETH,
+            AMOUNT_IN
+        );
+        uint256 deadline = block.timestamp + 120;
+
+        uint256 wethBalanceBeforeSwap = IERC20(WETH).balanceOf(taker);
+
+        vm.prank(taker);
+        (uint256 amountOut, address executedVenue) = router.swapV1(
+            USDC,
+            WETH,
+            AMOUNT_IN,
+            amountOutMin,
+            taker,
+            deadline
+        );
+
+        // The router tells us which venue actually settled the swap. Accept
+        // either the expected venue (its quote was best and it executed) or the
+        // fallback (`SWAP_ROUTER_02` quoted higher, or the PMM reverted at
+        // execution and the fallback engaged). Anything else is a routing bug.
+        assertTrue(
+            executedVenue == expectedVenue || executedVenue == SWAP_ROUTER_02,
+            string.concat("wrong execution venue for ", label)
+        );
+
+        _assertReceived(amountOut, amountOutMin, wethBalanceBeforeSwap);
+    }
+
+    /// @dev `swapViaVenueV1` counterpart of `_runSwapV1`. The caller pins the
+    /// venue, so there's no `executedVenue` return value to assert on — just
+    /// check the recipient received WETH and the returned `amountOut` matches
+    /// the balance delta.
+    function _runSwapViaVenueV1(address venue) internal {
+        uint256 amountOutMin = router.quoteVenueV1(venue, USDC, WETH, AMOUNT_IN);
+        uint256 deadline = block.timestamp + 120;
+
+        uint256 wethBalanceBeforeSwap = IERC20(WETH).balanceOf(taker);
+
+        vm.prank(taker);
+        uint256 amountOut = router.swapViaVenueV1(
+            venue,
+            USDC,
+            WETH,
+            AMOUNT_IN,
+            amountOutMin,
+            taker,
+            deadline
+        );
+
+        _assertReceived(amountOut, amountOutMin, wethBalanceBeforeSwap);
+    }
+
+    /// @dev `swapViaSelectedVenuesV1` counterpart. Requotes the subset via
+    /// `quoteSelectedVenuesV1` to derive `amountOutMin` (and the venue the
+    /// router will pick), then swaps and asserts the executed venue is that pick
+    /// or the fallback.
+    function _runSwapViaSelectedVenuesV1(
+        string memory label,
+        address[] memory venues
+    ) internal {
+        (uint256 amountOutMin, address quotedVenue) = router
+            .quoteSelectedVenuesV1(venues, USDC, WETH, AMOUNT_IN);
+        uint256 deadline = block.timestamp + 120;
+
+        uint256 wethBalanceBeforeSwap = IERC20(WETH).balanceOf(taker);
+
+        vm.prank(taker);
+        (uint256 amountOut, address executedVenue) = router
+            .swapViaSelectedVenuesV1(
+                venues,
+                USDC,
+                WETH,
+                AMOUNT_IN,
+                amountOutMin,
+                taker,
+                deadline
+            );
+
+        // Either the requoted winner executed, or it reverted and the fallback
+        // engaged.
+        assertTrue(
+            executedVenue == quotedVenue || executedVenue == SWAP_ROUTER_02,
+            string.concat("wrong execution venue for ", label)
+        );
+
+        _assertReceived(amountOut, amountOutMin, wethBalanceBeforeSwap);
+    }
+
+    /// @dev Asserts `quoteSelectedVenuesV1` over the single `venue` returns that
+    /// venue and a positive amount equal to the direct `quoteVenueV1` reading.
+    function _assertSelectedQuoteSingle(address venue) internal {
+        uint256 direct = router.quoteVenueV1(venue, USDC, WETH, AMOUNT_IN);
+        (uint256 amountOut, address picked) = router.quoteSelectedVenuesV1(
+            _venues(venue),
+            USDC,
+            WETH,
+            AMOUNT_IN
+        );
+
+        assertEq(picked, venue, "quoteSelectedVenuesV1 returned wrong venue");
+        assertGt(amountOut, 0, "quoteSelectedVenuesV1 returned zero");
+        assertEq(
+            amountOut,
+            direct,
+            "quoteSelectedVenuesV1 != quoteVenueV1"
+        );
+    }
+
+    /// @dev Shared post-swap assertions: output meets the floor and equals the
+    /// recipient's measured WETH balance delta.
+    function _assertReceived(
+        uint256 amountOut,
+        uint256 amountOutMin,
+        uint256 wethBalanceBeforeSwap
+    ) internal view {
+        assertGe(amountOut, amountOutMin, "amountOut < amountOutMin");
+        assertEq(
+            amountOut,
+            IERC20(WETH).balanceOf(taker) - wethBalanceBeforeSwap,
+            "amountOut != delta"
+        );
+    }
+}

--- a/test/PropAMMRouterForkTests.t.sol
+++ b/test/PropAMMRouterForkTests.t.sol
@@ -247,6 +247,50 @@ contract PropAMMRouterForkTests is Test {
     }
 
     // -------------------------------------------------------------
+    // Deadline enforcement — every swap entrypoint reverts `Expired`
+    // once `block.timestamp > deadline`, before pulling any funds.
+    // -------------------------------------------------------------
+
+    function test_swapV1RevertsAfterDeadline() public {
+        uint256 pastDeadline = block.timestamp - 1;
+        vm.prank(taker);
+        vm.expectRevert(PropAMMRouter.Expired.selector);
+        router.swapV1(USDC, WETH, AMOUNT_IN, 0, taker, pastDeadline);
+    }
+
+    function test_swapViaVenueV1RevertsAfterDeadline() public {
+        // Pass a valid venue so the deadline check (in `_coreSwap`) is the
+        // reason for the revert, not `UnknownVenue`.
+        uint256 pastDeadline = block.timestamp - 1;
+        vm.prank(taker);
+        vm.expectRevert(PropAMMRouter.Expired.selector);
+        router.swapViaVenueV1(
+            FERMI_ROUTER,
+            USDC,
+            WETH,
+            AMOUNT_IN,
+            0,
+            taker,
+            pastDeadline
+        );
+    }
+
+    function test_swapViaSelectedVenuesV1RevertsAfterDeadline() public {
+        uint256 pastDeadline = block.timestamp - 1;
+        vm.prank(taker);
+        vm.expectRevert(PropAMMRouter.Expired.selector);
+        router.swapViaSelectedVenuesV1(
+            _venues(FERMI_ROUTER),
+            USDC,
+            WETH,
+            AMOUNT_IN,
+            0,
+            taker,
+            pastDeadline
+        );
+    }
+
+    // -------------------------------------------------------------
     // quoteV1 — best quote across all venues
     // -------------------------------------------------------------
 

--- a/test/run_fork_tests.sh
+++ b/test/run_fork_tests.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Fork-test runner for `PropAMMRouterForkTests`.
+#
+# Queries Titan for the latest per-PMM stateOverride blob, flattens it
+# into three [{account, slot, value}, …] arrays (one per venue), and runs
+# the Solidity tests against a Foundry fork pinned to Titan's published
+# block.
+#
+# Prereqs:
+#   - `$ETH_RPC_URL` must point at a mainnet RPC (Alchemy / Infura / your
+#     own archive node — anywhere with `eth_getBlockByNumber` for the
+#     fork block).
+#   - `cast`, `jq`, `forge` on PATH.
+
+set -euo pipefail
+
+: "${ETH_RPC_URL:?must be set — mainnet RPC for the fork}"
+TITAN_URL="${TITAN_URL:-https://us.rpc.titanbuilder.xyz}"
+
+FERMI=0xb1076fe3ab5e28005c7c323bac5ac06a680d452e
+KIPSELI=0x5cdbe59400cc2efdcc2b54acca4a99fe00dd588c
+BEBOP=0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea
+
+echo "Fetching Titan stateOverrides from $TITAN_URL …"
+TITAN_RESP=$(curl -s -X POST "$TITAN_URL" \
+  -H 'content-type: application/json' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"titan_getPammStateOverrides","params":[]}')
+
+# Titan returns blockNumber as hex; vm.envUint wants decimal.
+TITAN_BLOCK=$(echo "$TITAN_RESP" \
+  | jq -r '.result.blockNumber' \
+  | xargs cast to-dec)
+
+# The RPC node often lags Titan by 1-2 blocks. `vm.createSelectFork`
+# refuses to fork at a future-to-the-RPC block, so cap to whatever the
+# RPC currently advertises. The 1-2 block delta has no effect on the
+# state Titan's override targets — Titan's stateDiff values reference
+# blocks well in the past (mapping_3 freshness etc., extracted below).
+RPC_LATEST=$(cast block-number --rpc-url "$ETH_RPC_URL")
+if [ "$TITAN_BLOCK" -gt "$RPC_LATEST" ]; then
+  echo "RPC lags Titan ($RPC_LATEST < $TITAN_BLOCK) — capping fork block to RPC head"
+  TITAN_BLOCK=$RPC_LATEST
+fi
+
+echo "Titan block: $TITAN_BLOCK"
+
+# Per venue we emit three flat arrays — storage / balance / nonce — so
+# Foundry's parseJson decodes each into its matching struct array. The
+# *code* override kind is intentionally skipped: Titan typically doesn't
+# include code overrides for these PMMs (and if it ever does, the bash
+# below would warn-and-skip; extend with `anvil_setCode`-equivalent if so).
+# Fields are alphabetical so parseJson's struct-field ordering matches.
+
+flatten_storage() {
+  echo "$TITAN_RESP" | jq -c --arg p "$1" '
+    [ .result[$p].stateOverride // {}
+      | to_entries[] as $a
+      | ($a.value.stateDiff // {}) | to_entries[]
+      | { account: $a.key, slot: .key, value: .value }
+    ]'
+}
+
+# Titan emits `balance` and `nonce` as RLP-style un-padded hex
+# (e.g. "0xc1ef398af17e3f", "0x2c7", "0x0"), while Foundry's `parseJson`
+# decoding into a `bytes32` struct field requires a full 32-byte hex
+# string. Left-pad to 64 hex chars before exporting so the Solidity-side
+# `abi.decode(_, (AccountValue[]))` doesn't revert.
+JQ_LPAD64='def lpad64(h):
+  (h | sub("^0x"; "")) as $hex
+  | ($hex | length) as $len
+  | if $len >= 64 then "0x" + $hex
+    else "0x" + ("0000000000000000000000000000000000000000000000000000000000000000" | .[0:(64-$len)]) + $hex
+    end;'
+
+flatten_balances() {
+  echo "$TITAN_RESP" | jq -c --arg p "$1" "$JQ_LPAD64"'
+    [ .result[$p].stateOverride // {}
+      | to_entries[]
+      | select(.value.balance != null)
+      | { account: .key, value: lpad64(.value.balance) }
+    ]'
+}
+
+flatten_nonces() {
+  echo "$TITAN_RESP" | jq -c --arg p "$1" "$JQ_LPAD64"'
+    [ .result[$p].stateOverride // {}
+      | to_entries[]
+      | select(.value.nonce != null)
+      | { account: .key, value: lpad64(.value.nonce) }
+    ]'
+}
+
+TITAN_FERMI_STORAGE=$(flatten_storage   "$FERMI")
+TITAN_FERMI_BALANCES=$(flatten_balances "$FERMI")
+TITAN_FERMI_NONCES=$(flatten_nonces     "$FERMI")
+
+TITAN_KIPSELI_STORAGE=$(flatten_storage   "$KIPSELI")
+TITAN_KIPSELI_BALANCES=$(flatten_balances "$KIPSELI")
+TITAN_KIPSELI_NONCES=$(flatten_nonces     "$KIPSELI")
+
+TITAN_BEBOP_STORAGE=$(flatten_storage   "$BEBOP")
+TITAN_BEBOP_BALANCES=$(flatten_balances "$BEBOP")
+TITAN_BEBOP_NONCES=$(flatten_nonces     "$BEBOP")
+
+# Bebop's maker doesn't push a price every block — at any moment Titan's
+# `result.blockNumber` can lead the block stored in Bebop's freshness
+# mapping (`mapping_3[0]` at slot keccak256(0,3) = 0x3617319a…) by
+# hundreds of blocks. The decompiled swap-side check is
+# `block.number != mapping_3[idx]` (strict equality), so Titan's Bebop
+# override is only internally consistent at whatever block value
+# `mapping_3[0]` stores. Extract it; the Bebop test will `vm.roll` to it.
+BEBOP_FRESH_BLOCK_HEX=$(echo "$TITAN_RESP" | jq -r '
+  .result["0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea"]
+    .stateOverride["0x160141a205f5ddcf096ba3f48b7ed21eb52c62ea"]
+    .stateDiff["0x3617319a054d772f909f7c479a2cebe5066e836a939412e32403c99029b92eff"]
+  // empty')
+if [ -n "$BEBOP_FRESH_BLOCK_HEX" ]; then
+  BEBOP_FRESH_BLOCK=$(cast to-dec "$BEBOP_FRESH_BLOCK_HEX")
+else
+  BEBOP_FRESH_BLOCK=$TITAN_BLOCK
+fi
+echo "Bebop fresh block:  $BEBOP_FRESH_BLOCK (titan block: $TITAN_BLOCK, delta: $((TITAN_BLOCK - BEBOP_FRESH_BLOCK)))"
+
+export ETH_RPC_URL
+export TITAN_BLOCK
+export BEBOP_FRESH_BLOCK
+export TITAN_FERMI_STORAGE TITAN_FERMI_BALANCES TITAN_FERMI_NONCES
+export TITAN_KIPSELI_STORAGE TITAN_KIPSELI_BALANCES TITAN_KIPSELI_NONCES
+export TITAN_BEBOP_STORAGE TITAN_BEBOP_BALANCES TITAN_BEBOP_NONCES
+
+cd "$(dirname "$0")/.."
+
+forge test \
+  --match-contract PropAMMRouterForkTests \
+  --gas-report \
+  -vvvv \
+  "$@"


### PR DESCRIPTION
This PR adds Foundry tests for the PropAMMRouter contract.
The tests run against a mainnet fork, and execute quotes and swaps, overriding the state with Titan updates.

The tests can be run with:

```bash
export ETH_RPC_URL=https://ethereum-rpc.publicnode.com
./test/run_fork_tests.sh
```

The `test/run_fork_tests.sh` script fetches and parses the state overrides from the Titan API, exports them as environment variables and run the foundry tests.

The tests are a little bit flaky, since sometimes the Fermi tests fail with `No quotes available` error.