### PR TITLE
Frontend fees

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
-	url = https://github.com/forge-rs/forge-std
+	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/openzeppelin-foundry-upgrades"]
 	path = lib/openzeppelin-foundry-upgrades
 	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ As a consequence:
 - `quoteV1` and `quoteVenueV1` are not `view`. They must be called via `eth_call` (staticcall) from off-chain so the simulated swaps are rolled back automatically.
 - The Kipseli simulation pulls `tokenIn` from the router's own balance. When quoting against Kipseli (directly via `quoteVenueV1`, or implicitly through `quoteV1`), the RPC call must include a `stateDiff` override that gives the router a sufficient balance of `tokenIn`. Without the override, the Kipseli branch is silently skipped while the other branches still quote.
 
+### Frontend fees
+
+Three implementation-only entrypoints take a per-call, basis-point fee from the swap
+**output token** and forward it to a caller-supplied recipient. They are **not** part of
+`IPropAMMRouter`; encode them against the deployed `PropAMMRouter`.
+
+- `swapWithFeeV1(tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline, fee)`
+- `swapViaVenueWithFeeV1(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline, fee)`
+- `swapViaSelectedVenuesWithFeeV1(venues, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline, fee)`
+
+`fee` is a `FrontendFee { uint16 bps; address recipient }`:
+- `bps` is the fee in basis points, capped at `MAX_FEE_BPS` (100 = 1.00%).
+- `recipient` receives the fee in `tokenOut`; must be non-zero.
+
+`amountOutMin` is the **net** amount the user must receive **after** the fee — the router
+grosses it up internally, so the user always nets at least `amountOutMin`. The returned
+`amountOut` and the `Swapped` event's `amountOut` are the **net** delivered to `recipient`.
+A `FrontendFeeCharged` event is emitted whenever a non-zero fee is taken. Quote functions
+are unchanged and return **gross** output; a frontend nets out by subtracting its own bps.
+
 ## Prerequisites
 
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) installed.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.35;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -16,8 +17,17 @@ import {KIPSELI_PAMM, IKipseliPAMM} from "./interfaces/IKipseliPAMM.sol";
 import {KIPSELI_QUOTER, IKipseliQuoter} from "./interfaces/IKipseliQuoter.sol";
 import {UniV3Router} from "./libraries/UniV3Router.sol";
 
+/// @notice Fee parameters for the `*WithFeeV1` entrypoints. Bundled into a struct
+/// so each entrypoint stays within the EVM stack limit without enabling `via_ir`.
+/// @param bps Fee in basis points (1/10_000 of the output). Must be <= `MAX_FEE_BPS`.
+/// @param recipient Address that receives the fee in `tokenOut`. Must be non-zero.
+struct FrontendFee {
+    uint16 bps;
+    address recipient;
+}
+
 /// @title PropAMMRouter
-/// @notice Routes single-hop swaps to a propAMM and falls back through a fallback 
+/// @notice Routes single-hop swaps to a propAMM and falls back through a fallback
 /// venue if the chosen venue reverts.
 /// @dev Designed to live behind a UUPS proxy. The fallback path is wired at
 /// initialization via `fallbackSwapRouter` and `fallbackQuoter`
@@ -40,6 +50,11 @@ contract PropAMMRouter is
     address public fallbackQuoter;
     /// @notice Fee for the fallback venue.
     uint24 public fallbackFee;
+
+    /// @notice Hard cap on a frontend fee, in basis points (1.00%).
+    uint16 public constant MAX_FEE_BPS = 100;
+    /// @notice Basis-point denominator (100% = 10_000 bps).
+    uint16 public constant BPS_DENOMINATOR = 10_000;
 
     /// @notice Thrown when `_dispatchVenue` is called by anyone other than this
     /// contract itself, i.e. outside of the `try`-wrapped self-call made by
@@ -72,6 +87,10 @@ contract PropAMMRouter is
     error InvalidFallbackFee(uint24 fee);
     /// @notice Thrown when an address argument that must be non-zero is zero.
     error ZeroAddress();
+    /// @notice Thrown when a requested frontend fee exceeds `MAX_FEE_BPS`.
+    /// @param requested The caller-supplied fee in basis points.
+    /// @param max The maximum allowed fee (`MAX_FEE_BPS`).
+    error FeeBpsTooHigh(uint16 requested, uint16 max);
 
     // `Swapped` is declared in IPropAMMRouter (part of the published interface)
     // and inherited here. The operational events below are implementation
@@ -94,6 +113,17 @@ contract PropAMMRouter is
     /// @param to The recipient of the rescued tokens.
     /// @param amount The amount transferred.
     event TokensRescued(address indexed token, address indexed to, uint256 amount);
+    /// @notice Emitted when a frontend fee is skimmed from a `*WithFeeV1` swap output.
+    /// @param feeRecipient The address that received the fee.
+    /// @param tokenOut The output token the fee was taken in.
+    /// @param feeAmount The fee amount transferred to `feeRecipient`.
+    /// @param payer The account that invoked the swap and bore the fee.
+    event FrontendFeeCharged(
+        address indexed feeRecipient,
+        address indexed tokenOut,
+        uint256 feeAmount,
+        address indexed payer
+    );
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -145,11 +145,13 @@ contract PropAMMRouter is
         require(block.timestamp <= deadline, Expired());
         (uint256 bestQuote, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
         require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
-        return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        (amountOut, executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Swaps via the `venue`. It must be a callable venue or the 
+    /// @dev Swaps via the `venue`. It must be a callable venue or the
     /// fallback venue named by the `fallbackSwapRouter` address.
     function swapViaVenueV1(
         address venue,
@@ -161,7 +163,10 @@ contract PropAMMRouter is
         uint256 deadline
     ) public whenNotPaused nonReentrant returns (uint256 amountOut) {
         require(_isVenue(venue), UnknownVenue());
-        (amountOut,) = _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        address executedVenue;
+        (amountOut, executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
     /// @inheritdoc IPropAMMRouter
@@ -187,14 +192,18 @@ contract PropAMMRouter is
         // Reject when none of the selected venues could be priced (venue stays address(0)).
         require(venue != address(0), NoQuotesAvailable());
         require(bestQuote >= amountOutMin, QuoteBelowMinimum(amountOutMin, bestQuote));
-        return _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        (amountOut, executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
     /// @notice Pulls funds once and executes a swap, attempting `venue` first
     /// and recovering via the fallback if it fails.
     /// @dev Shared core for `swapV1` and `swapViaVenueV1`; unguarded so the two
     /// public entrypoints can each apply `whenNotPaused`/`nonReentrant` without
-    /// re-entering the guard through one another. 
+    /// re-entering the guard through one another. The `Swapped` event is emitted
+    /// by the calling entrypoint (not here) so the fee entrypoints can log the
+    /// net amount and real recipient.
     /// @param venue The propAMM to attempt first, or `fallbackSwapRouter`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
@@ -225,7 +234,6 @@ contract PropAMMRouter is
             ) returns (
                 uint256 amountOut_
             ) {
-                _emitSwapped(venue, tokenIn, tokenOut, amountIn, amountOut_, recipient);
                 return (amountOut_, venue);
             } catch {
                 // Fall through to the Uniswap V3 fallback below.
@@ -235,16 +243,16 @@ contract PropAMMRouter is
         swapViaUniswapV3(tokenIn, tokenOut, amountIn, amountOutMin, recipient);
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;
         require(amountOut >= amountOutMin, InsufficientOutput(amountOutMin, amountOut));
-        _emitSwapped(fallbackSwapRouter, tokenIn, tokenOut, amountIn, amountOut, recipient);
         return (amountOut, fallbackSwapRouter);
     }
 
     /// @notice Logs a completed swap.
-    /// @dev Wraps the `Swapped` emit so `_coreSwap` does not carry the event's
-    /// arguments live on its (already param-heavy) stack at the emit site —
-    /// avoids a stack-too-deep without enabling `viaIR`. `msg.sender` is read
-    /// here and equals `_coreSwap`'s caller (and the entrypoint's), since
-    /// internal calls preserve the message context.
+    /// @dev Wraps the `Swapped` emit so the calling entrypoint does not carry
+    /// the event's arguments live on its (already param-heavy) stack at the
+    /// emit site — avoids a stack-too-deep without enabling `viaIR`. Called
+    /// from the public swap entrypoints after `_coreSwap` returns. `msg.sender`
+    /// is read here and equals the entrypoint's caller, since internal calls
+    /// preserve the message context.
     /// @param marketMaker The venue that filled, or `fallbackSwapRouter`. Placed
     /// first (not in `Swapped`'s field order) so the deepest `_coreSwap` local
     /// (`venue`) is read at the shallowest stack reach — another stack-too-deep

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -241,6 +241,40 @@ contract PropAMMRouter is
         _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
+    /// @notice Caller-named-venue swap that skims a frontend fee from the output token.
+    /// @dev Implementation-only. Like `swapViaVenueV1` plus the fee skim; the underlying
+    /// swap is routed to this contract, then fee + net are forwarded. Reverts `UnknownVenue`
+    /// if `venue` is neither a whitelisted propAMM nor the fallback address.
+    /// @param venue The venue address (propAMM or the fallback router address).
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum NET `tokenOut` the user must receive (after the fee).
+    /// @param recipient The address that receives the net `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @param fee The frontend fee (bps + recipient).
+    /// @return amountOut The net `tokenOut` delivered to `recipient`.
+    function swapViaVenueWithFeeV1(
+        address venue,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline,
+        FrontendFee calldata fee
+    ) external whenNotPaused nonReentrant returns (uint256 amountOut) {
+        _validateFee(fee);
+        require(_isVenue(venue), UnknownVenue());
+
+        uint256 grossMin = _grossUp(amountOutMin, fee.bps);
+        (uint256 delivered, address executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, grossMin, address(this), deadline);
+
+        amountOut = _skimAndDisburse(tokenOut, delivered, fee, recipient);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
+    }
+
     /// @inheritdoc IPropAMMRouter
     /// @dev Requotes ONLY the caller-supplied `venues` on-chain via
     /// `_pickBestVenueFrom`, then executes the best through `_coreSwap`. As with

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -180,6 +180,48 @@ contract PropAMMRouter is
         _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
+    /// @notice Best-venue swap that skims a frontend fee from the output token.
+    /// @dev Implementation-only (not in `IPropAMMRouter`). Validates `fee`, grosses up
+    /// the net `amountOutMin` so the user still nets at least their minimum, routes the
+    /// swap to this contract, then forwards the fee and the net. Emits `Swapped` with the
+    /// net amount and the real `recipient`. `whenNotPaused`/`nonReentrant` like `swapV1`.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum NET `tokenOut` the user must receive (after the fee).
+    /// @param recipient The address that receives the net `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @param fee The frontend fee (bps + recipient).
+    /// @return amountOut The net `tokenOut` delivered to `recipient`.
+    /// @return executedVenue The venue that filled, or the fallback venue address.
+    function swapWithFeeV1(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline,
+        FrontendFee calldata fee
+    ) external whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
+        _validateFee(fee);
+        require(block.timestamp <= deadline, Expired());
+
+        uint256 grossMin = _grossUp(amountOutMin, fee.bps);
+        address venue;
+        {
+            uint256 bestQuote;
+            (bestQuote, venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
+            require(bestQuote >= grossMin, QuoteBelowMinimum(grossMin, bestQuote));
+        }
+
+        uint256 delivered;
+        (delivered, executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, grossMin, address(this), deadline);
+
+        amountOut = _skimAndDisburse(tokenOut, delivered, fee, recipient);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
+    }
+
     /// @inheritdoc IPropAMMRouter
     /// @dev Swaps via the `venue`. It must be a callable venue or the
     /// fallback venue named by the `fallbackSwapRouter` address.
@@ -301,6 +343,56 @@ contract PropAMMRouter is
         address recipient
     ) private {
         emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient, marketMaker);
+    }
+
+    /// @notice Reverts unless the frontend fee is within cap and has a real recipient.
+    /// @param fee The caller-supplied fee parameters.
+    function _validateFee(FrontendFee calldata fee) private pure {
+        require(fee.bps <= MAX_FEE_BPS, FeeBpsTooHigh(fee.bps, MAX_FEE_BPS));
+        require(fee.recipient != address(0), ZeroAddress());
+    }
+
+    /// @notice Grosses up a net `amountOutMin` so the post-fee output still meets it.
+    /// @dev `ceilDiv` rounds up to avoid a 1-wei false revert at the slippage boundary.
+    /// Safe from divide-by-zero because `feeBps <= MAX_FEE_BPS < BPS_DENOMINATOR`.
+    /// @param amountOutMin The net minimum the user must receive.
+    /// @param feeBps The fee in basis points.
+    /// @return grossMin The gross minimum the underlying swap must deliver.
+    function _grossUp(uint256 amountOutMin, uint16 feeBps) private pure returns (uint256 grossMin) {
+        grossMin = Math.ceilDiv(amountOutMin * BPS_DENOMINATOR, BPS_DENOMINATOR - feeBps);
+    }
+
+    /// @notice Floored basis-point fee on `amount`.
+    /// @param amount The gross amount the fee is taken from.
+    /// @param feeBps The fee in basis points.
+    /// @return The fee amount (rounds down, favoring the user).
+    function _feeAmount(uint256 amount, uint16 feeBps) private pure returns (uint256) {
+        return amount * feeBps / BPS_DENOMINATOR;
+    }
+
+    /// @notice Splits `delivered` tokenOut (held by this contract) into fee + net,
+    /// forwards the fee to `fee.recipient` and the net to `recipient`.
+    /// @dev Zero-value legs are skipped (gas + tokens that revert on 0-value transfers).
+    /// @param tokenOut The output token held by this contract.
+    /// @param delivered The gross amount this contract received from the swap.
+    /// @param fee The fee parameters.
+    /// @param recipient The end recipient of the net output.
+    /// @return net The amount forwarded to `recipient`.
+    function _skimAndDisburse(
+        address tokenOut,
+        uint256 delivered,
+        FrontendFee calldata fee,
+        address recipient
+    ) private returns (uint256 net) {
+        uint256 feeAmt = _feeAmount(delivered, fee.bps);
+        net = delivered - feeAmt;
+        if (feeAmt > 0) {
+            IERC20(tokenOut).safeTransfer(fee.recipient, feeAmt);
+            emit FrontendFeeCharged(fee.recipient, tokenOut, feeAmt, msg.sender);
+        }
+        if (net > 0) {
+            IERC20(tokenOut).safeTransfer(recipient, net);
+        }
     }
 
     /// @notice Executes a swap on a venue with funds already held by this contract.

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -303,6 +303,50 @@ contract PropAMMRouter is
         _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }
 
+    /// @notice Best-of-a-subset swap that skims a frontend fee from the output token.
+    /// @dev Implementation-only. Like `swapViaSelectedVenuesV1` plus the fee skim; requotes
+    /// only `venues`, grosses up the net min, routes the swap to this contract, then forwards
+    /// fee + net. Reverts `NoQuotesAvailable` if none of `venues` can be priced.
+    /// @param venues The venues to consider — a subset of the available venues.
+    /// @param tokenIn The token being sold.
+    /// @param tokenOut The token being bought.
+    /// @param amountIn The exact amount of `tokenIn` to sell.
+    /// @param amountOutMin The minimum NET `tokenOut` the user must receive (after the fee).
+    /// @param recipient The address that receives the net `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @param fee The frontend fee (bps + recipient).
+    /// @return amountOut The net `tokenOut` delivered to `recipient`.
+    /// @return executedVenue The venue that filled, or the fallback venue address.
+    function swapViaSelectedVenuesWithFeeV1(
+        address[] calldata venues,
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline,
+        FrontendFee calldata fee
+    ) external whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
+        _validateFee(fee);
+        require(block.timestamp <= deadline, Expired());
+
+        uint256 grossMin = _grossUp(amountOutMin, fee.bps);
+        address venue;
+        {
+            uint256 bestQuote;
+            (bestQuote, venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
+            require(venue != address(0), NoQuotesAvailable());
+            require(bestQuote >= grossMin, QuoteBelowMinimum(grossMin, bestQuote));
+        }
+
+        uint256 delivered;
+        (delivered, executedVenue) =
+            _coreSwap(venue, tokenIn, tokenOut, amountIn, grossMin, address(this), deadline);
+
+        amountOut = _skimAndDisburse(tokenOut, delivered, fee, recipient);
+        _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
+    }
+
     /// @notice Pulls funds once and executes a swap, attempting `venue` first
     /// and recovering via the fallback if it fails.
     /// @dev Shared core for `swapV1` and `swapViaVenueV1`; unguarded so the two

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -5,7 +5,7 @@ import {Test, Vm} from "forge-std/Test.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IPropAMMRouter} from "../src/interfaces/IPropAMMRouter.sol";
-import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+import {PropAMMRouter, FrontendFee} from "../src/PropAMMRouter.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockV3SwapRouter} from "./mocks/MockV3SwapRouter.sol";
 import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
@@ -46,6 +46,25 @@ contract PropAMMRouterFeeTest is Test {
         quoter.setQuote(delivered);
         vm.prank(user);
         tokenIn.approve(address(router), amountIn);
+    }
+
+    // feeBps = 50 (0.5%); delivered 1_000e18 -> fee 5e18, user 995e18.
+    function test_swapWithFee_takesFeeAndPaysUser() public {
+        _prepare(1_000e18, 1_000e18);
+        uint256 expectedFee = 1_000e18 * 50 / 10_000; // 5e18
+        uint256 expectedNet = 1_000e18 - expectedFee; // 995e18
+
+        vm.prank(user);
+        (uint256 amountOut, address executedVenue) = router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, expectedNet,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+
+        assertEq(amountOut, expectedNet);
+        assertEq(executedVenue, address(swapRouter));
+        assertEq(tokenOut.balanceOf(user), expectedNet);
+        assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
+        assertEq(tokenOut.balanceOf(address(router)), 0);
     }
 
     // Characterization: existing fee-free swapV1 routes through the fallback and

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IPropAMMRouter} from "../src/interfaces/IPropAMMRouter.sol";
+import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockV3SwapRouter} from "./mocks/MockV3SwapRouter.sol";
+import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
+
+contract PropAMMRouterFeeTest is Test {
+    PropAMMRouter router;
+    MockV3SwapRouter swapRouter;
+    MockQuoterV2 quoter;
+    MockERC20 tokenIn;
+    MockERC20 tokenOut;
+
+    address owner = makeAddr("owner");
+    address user = makeAddr("user");
+    address feeRecipient = makeAddr("feeRecipient");
+
+    function _deployRouter() internal returns (PropAMMRouter) {
+        PropAMMRouter impl = new PropAMMRouter();
+        bytes memory data = abi.encodeCall(
+            PropAMMRouter.initialize, (address(swapRouter), address(quoter), owner)
+        );
+        return PropAMMRouter(address(new ERC1967Proxy(address(impl), data)));
+    }
+
+    function setUp() public {
+        swapRouter = new MockV3SwapRouter();
+        quoter = new MockQuoterV2();
+        tokenIn = new MockERC20("In", "IN");
+        tokenOut = new MockERC20("Out", "OUT");
+        router = _deployRouter();
+    }
+
+    // Funds the user with tokenIn, pre-funds the mock swap router with tokenOut to
+    // deliver, sets the quote + delivered amount, and approves the router.
+    function _prepare(uint256 amountIn, uint256 delivered) internal {
+        tokenIn.mint(user, amountIn);
+        tokenOut.mint(address(swapRouter), delivered);
+        swapRouter.setAmountOut(delivered);
+        quoter.setQuote(delivered);
+        vm.prank(user);
+        tokenIn.approve(address(router), amountIn);
+    }
+
+    // Characterization: existing fee-free swapV1 routes through the fallback and
+    // emits Swapped(recipient = user, amountOut = delivered). Guards Task 2.
+    function test_swapV1_fallback_emitsSwapped() public {
+        _prepare(1_000e18, 990e18);
+
+        vm.expectEmit(true, true, true, true, address(router));
+        emit IPropAMMRouter.Swapped(
+            user, address(tokenIn), address(tokenOut), 1_000e18, 990e18, user, address(swapRouter)
+        );
+
+        vm.prank(user);
+        (uint256 amountOut, address executedVenue) =
+            router.swapV1(address(tokenIn), address(tokenOut), 1_000e18, 990e18, user, block.timestamp + 1);
+
+        assertEq(amountOut, 990e18);
+        assertEq(executedVenue, address(swapRouter));
+        assertEq(tokenOut.balanceOf(user), 990e18);
+        assertEq(tokenOut.balanceOf(address(router)), 0);
+    }
+}

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -7,6 +7,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {IPropAMMRouter} from "../src/interfaces/IPropAMMRouter.sol";
 import {PropAMMRouter, FrontendFee} from "../src/PropAMMRouter.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockFeeOnTransferERC20} from "./mocks/MockFeeOnTransferERC20.sol";
 import {MockV3SwapRouter} from "./mocks/MockV3SwapRouter.sol";
 import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
 
@@ -191,6 +192,38 @@ contract PropAMMRouterFeeTest is Test {
             address(tokenIn), address(tokenOut), 1_000e18, 0,
             user, block.timestamp - 1, FrontendFee({bps: 50, recipient: feeRecipient})
         );
+    }
+
+    function _afterFot(uint256 v) internal pure returns (uint256) {
+        return v - v * 100 / 10_000; // 1% burn
+    }
+
+    function test_swapWithFee_feeOnTransferTokenOut() public {
+        MockFeeOnTransferERC20 fotOut = new MockFeeOnTransferERC20("FOT", "FOT", 100); // 1%
+        uint256 routerOut = 1_000e18;
+        tokenIn.mint(user, 1_000e18);
+        fotOut.mint(address(swapRouter), routerOut);
+        swapRouter.setAmountOut(routerOut);
+        quoter.setQuote(routerOut);
+        vm.prank(user);
+        tokenIn.approve(address(router), 1_000e18);
+
+        // Mock transfers routerOut to the router, burning 1% on the way in.
+        uint256 delivered = _afterFot(routerOut);
+        uint256 fee = delivered * 50 / 10_000;
+        uint256 net = delivered - fee;
+
+        vm.prank(user);
+        (uint256 amountOut,) = router.swapWithFeeV1(
+            address(tokenIn), address(fotOut), 1_000e18, 0,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+
+        assertEq(amountOut, net);
+        // Each outbound leg burns another 1%.
+        assertEq(fotOut.balanceOf(feeRecipient), _afterFot(fee));
+        assertEq(fotOut.balanceOf(user), _afterFot(net));
+        assertEq(fotOut.balanceOf(address(router)), 0);
     }
 
     // Characterization: existing fee-free swapV1 routes through the fallback and

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -67,6 +67,24 @@ contract PropAMMRouterFeeTest is Test {
         assertEq(tokenOut.balanceOf(address(router)), 0);
     }
 
+    function test_swapViaVenueWithFee_fallback_takesFee() public {
+        _prepare(1_000e18, 1_000e18);
+        uint256 expectedFee = 1_000e18 * 50 / 10_000;
+        uint256 expectedNet = 1_000e18 - expectedFee;
+
+        vm.prank(user);
+        uint256 amountOut = router.swapViaVenueWithFeeV1(
+            address(swapRouter), // the fallback venue address is a valid venue
+            address(tokenIn), address(tokenOut), 1_000e18, expectedNet,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+
+        assertEq(amountOut, expectedNet);
+        assertEq(tokenOut.balanceOf(user), expectedNet);
+        assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
+        assertEq(tokenOut.balanceOf(address(router)), 0);
+    }
+
     // Characterization: existing fee-free swapV1 routes through the fallback and
     // emits Swapped(recipient = user, amountOut = delivered). Guards Task 2.
     function test_swapV1_fallback_emitsSwapped() public {

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -226,6 +226,29 @@ contract PropAMMRouterFeeTest is Test {
         assertEq(fotOut.balanceOf(address(router)), 0);
     }
 
+    // For any feeBps in [0, MAX_FEE_BPS] and any delivered >= grossMin, the user nets
+    // at least amountOutMin, the fee is the floored bps, and nothing is stranded.
+    function testFuzz_swapWithFee_netNeverBelowMin(uint16 rawBps, uint256 netMin, uint256 delivered) public {
+        uint16 bps = uint16(bound(rawBps, 0, 100));
+        netMin = bound(netMin, 0, 1e27);
+        uint256 grossMin = Math.ceilDiv(netMin * 10_000, 10_000 - bps);
+        delivered = bound(delivered, grossMin == 0 ? 1 : grossMin, 1e30);
+
+        _prepare(1e18, delivered);
+
+        vm.prank(user);
+        (uint256 amountOut,) = router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1e18, netMin,
+            user, block.timestamp + 1, FrontendFee({bps: bps, recipient: feeRecipient})
+        );
+
+        uint256 expectedFee = delivered * bps / 10_000;
+        assertEq(amountOut, delivered - expectedFee);
+        assertGe(amountOut, netMin); // the core guarantee
+        assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
+        assertEq(tokenOut.balanceOf(address(router)), 0);
+    }
+
     // Characterization: existing fee-free swapV1 routes through the fallback and
     // emits Swapped(recipient = user, amountOut = delivered). Guards Task 2.
     function test_swapV1_fallback_emitsSwapped() public {

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -85,6 +85,26 @@ contract PropAMMRouterFeeTest is Test {
         assertEq(tokenOut.balanceOf(address(router)), 0);
     }
 
+    function test_swapViaSelectedVenuesWithFee_takesFee() public {
+        _prepare(1_000e18, 1_000e18);
+        uint256 expectedFee = 1_000e18 * 50 / 10_000;
+        uint256 expectedNet = 1_000e18 - expectedFee;
+
+        address[] memory venues = new address[](1);
+        venues[0] = address(swapRouter); // the fallback venue, only priceable candidate
+
+        vm.prank(user);
+        (uint256 amountOut, address executedVenue) = router.swapViaSelectedVenuesWithFeeV1(
+            venues, address(tokenIn), address(tokenOut), 1_000e18, expectedNet,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+
+        assertEq(amountOut, expectedNet);
+        assertEq(executedVenue, address(swapRouter));
+        assertEq(tokenOut.balanceOf(user), expectedNet);
+        assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
+    }
+
     // Characterization: existing fee-free swapV1 routes through the fallback and
     // emits Swapped(recipient = user, amountOut = delivered). Guards Task 2.
     function test_swapV1_fallback_emitsSwapped() public {

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -10,6 +10,8 @@ import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockFeeOnTransferERC20} from "./mocks/MockFeeOnTransferERC20.sol";
 import {MockV3SwapRouter} from "./mocks/MockV3SwapRouter.sol";
 import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
+import {BEBOP_ROUTER} from "../src/interfaces/IBebopRouter.sol";
+import {MockBebop} from "./mocks/MockBebop.sol";
 
 contract PropAMMRouterFeeTest is Test {
     PropAMMRouter router;
@@ -246,6 +248,31 @@ contract PropAMMRouterFeeTest is Test {
         assertEq(amountOut, delivered - expectedFee);
         assertGe(amountOut, netMin); // the core guarantee
         assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
+        assertEq(tokenOut.balanceOf(address(router)), 0);
+    }
+
+    function test_swapViaVenueWithFee_bebopCustodyPath() public {
+        // Place mock Bebop code at the hard-coded BEBOP_ROUTER address.
+        vm.etch(BEBOP_ROUTER, address(new MockBebop()).code);
+
+        uint256 delivered = 1_000e18;
+        tokenIn.mint(user, 1_000e18);
+        tokenOut.mint(BEBOP_ROUTER, delivered); // Bebop delivers this to the router
+        vm.prank(user);
+        tokenIn.approve(address(router), 1_000e18);
+
+        uint256 fee = delivered * 50 / 10_000;
+        uint256 net = delivered - fee;
+
+        vm.prank(user);
+        uint256 amountOut = router.swapViaVenueWithFeeV1(
+            BEBOP_ROUTER, address(tokenIn), address(tokenOut), 1_000e18, net,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+
+        assertEq(amountOut, net);
+        assertEq(tokenOut.balanceOf(user), net);
+        assertEq(tokenOut.balanceOf(feeRecipient), fee);
         assertEq(tokenOut.balanceOf(address(router)), 0);
     }
 

--- a/test/PropAMMRouterFee.t.sol
+++ b/test/PropAMMRouterFee.t.sol
@@ -105,6 +105,94 @@ contract PropAMMRouterFeeTest is Test {
         assertEq(tokenOut.balanceOf(feeRecipient), expectedFee);
     }
 
+    function test_swapWithFee_revertsFeeTooHigh() public {
+        _prepare(1_000e18, 1_000e18);
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.FeeBpsTooHigh.selector, uint16(101), uint16(100)));
+        router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, 0,
+            user, block.timestamp + 1, FrontendFee({bps: 101, recipient: feeRecipient})
+        );
+    }
+
+    function test_swapWithFee_revertsZeroFeeRecipient() public {
+        _prepare(1_000e18, 1_000e18);
+        vm.prank(user);
+        vm.expectRevert(PropAMMRouter.ZeroAddress.selector);
+        router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, 0,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: address(0)})
+        );
+    }
+
+    // amountOutMin is net; grossMin > best quote (900e18) so the pre-pull check rejects
+    // with the grossed-up minimum.
+    function test_swapWithFee_revertsQuoteBelowGrossMin() public {
+        _prepare(1_000e18, 900e18); // quote + delivered both 900e18
+        uint256 netMin = 950e18;
+        uint256 grossMin = Math.ceilDiv(netMin * 10_000, 10_000 - 50);
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(PropAMMRouter.QuoteBelowMinimum.selector, grossMin, uint256(900e18)));
+        router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, netMin,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+    }
+
+    function test_swapWithFee_zeroFee_paysFullAndNoFeeEvent() public {
+        _prepare(1_000e18, 1_000e18);
+        vm.recordLogs();
+        vm.prank(user);
+        (uint256 amountOut,) = router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, 1_000e18,
+            user, block.timestamp + 1, FrontendFee({bps: 0, recipient: feeRecipient})
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(
+                logs[i].topics[0] != PropAMMRouter.FrontendFeeCharged.selector,
+                "FrontendFeeCharged must not fire at zero fee"
+            );
+        }
+        assertEq(amountOut, 1_000e18);
+        assertEq(tokenOut.balanceOf(user), 1_000e18);
+        assertEq(tokenOut.balanceOf(feeRecipient), 0);
+    }
+
+    function test_swapWithFee_tinyAmountFloorsFeeToZero() public {
+        // grossMin = ceilDiv(100 * 10_000, 9_950) = 101; deliver 101.
+        _prepare(10, 101);
+        vm.prank(user);
+        (uint256 amountOut,) = router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 10, 100,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+        assertEq(amountOut, 101); // fee = 101*50/10_000 = 0 (floored)
+        assertEq(tokenOut.balanceOf(feeRecipient), 0);
+    }
+
+    function test_swapWithFee_revertsWhenPaused() public {
+        vm.prank(owner);
+        router.pause();
+        _prepare(1_000e18, 1_000e18);
+        vm.prank(user);
+        vm.expectRevert(); // PausableUpgradeable.EnforcedPause
+        router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, 0,
+            user, block.timestamp + 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+    }
+
+    function test_swapWithFee_revertsPastDeadline() public {
+        _prepare(1_000e18, 1_000e18);
+        vm.prank(user);
+        vm.expectRevert(PropAMMRouter.Expired.selector);
+        router.swapWithFeeV1(
+            address(tokenIn), address(tokenOut), 1_000e18, 0,
+            user, block.timestamp - 1, FrontendFee({bps: 50, recipient: feeRecipient})
+        );
+    }
+
     // Characterization: existing fee-free swapV1 routes through the fallback and
     // emits Swapped(recipient = user, amountOut = delivered). Guards Task 2.
     function test_swapV1_fallback_emitsSwapped() public {

--- a/test/mocks/MockBebop.sol
+++ b/test/mocks/MockBebop.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockBebop {
+    function swap(address tokenIn, address tokenOut, uint256 amountIn, uint256, uint256) external {
+        IERC20(tokenIn).transferFrom(msg.sender, address(this), amountIn);
+        IERC20(tokenOut).transfer(msg.sender, IERC20(tokenOut).balanceOf(address(this)));
+    }
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name_, string memory symbol_) ERC20(name_, symbol_) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/mocks/MockFeeOnTransferERC20.sol
+++ b/test/mocks/MockFeeOnTransferERC20.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferERC20 is ERC20 {
+    uint256 public immutable transferFeeBps;
+
+    constructor(string memory name_, string memory symbol_, uint256 transferFeeBps_)
+        ERC20(name_, symbol_)
+    {
+        transferFeeBps = transferFeeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    // Burns transferFeeBps of every transfer between non-zero addresses.
+    function _update(address from, address to, uint256 value) internal override {
+        if (from == address(0) || to == address(0)) {
+            super._update(from, to, value);
+            return;
+        }
+        uint256 burned = value * transferFeeBps / 10_000;
+        super._update(from, to, value - burned);
+        if (burned > 0) {
+            super._update(from, address(0xdead), burned);
+        }
+    }
+}

--- a/test/mocks/MockQuoterV2.sol
+++ b/test/mocks/MockQuoterV2.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IQuoterV2} from "@uniswap/v3-periphery/contracts/interfaces/IQuoterV2.sol";
+
+contract MockQuoterV2 {
+    uint256 public quoteToReturn;
+
+    function setQuote(uint256 quote) external {
+        quoteToReturn = quote;
+    }
+
+    function quoteExactInputSingle(IQuoterV2.QuoteExactInputSingleParams calldata)
+        external
+        returns (uint256 amountOut, uint160 sqrtPriceX96After, uint32 initializedTicksCrossed, uint256 gasEstimate)
+    {
+        return (quoteToReturn, 0, 0, 0);
+    }
+}

--- a/test/mocks/MockV3SwapRouter.sol
+++ b/test/mocks/MockV3SwapRouter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IV3SwapRouter} from "@uniswap/swap-router-contracts/contracts/interfaces/IV3SwapRouter.sol";
+
+contract MockV3SwapRouter {
+    uint256 public amountOutToReturn;
+
+    function setAmountOut(uint256 amountOut) external {
+        amountOutToReturn = amountOut;
+    }
+
+    function exactInputSingle(IV3SwapRouter.ExactInputSingleParams calldata params)
+        external
+        returns (uint256 amountOut)
+    {
+        IERC20(params.tokenIn).transferFrom(msg.sender, address(this), params.amountIn);
+        amountOut = amountOutToReturn;
+        // Deliver pre-funded tokenOut to the recipient (a FoT token burns here).
+        IERC20(params.tokenOut).transfer(params.recipient, amountOut);
+    }
+}


### PR DESCRIPTION
This PR adds three new swap entrypoints (swapWithFeeV1, swapViaVenueWithFeeV1, swapViaSelectedVenuesWithFeeV1) that skim a caller-specified fee from the output token and forward it to a frontend recipient. 

The fee is expressed in basis points via a new FrontendFee struct, capped at MAX_FEE_BPS = 100 (1%, enforced by FeeBpsTooHigh), skimmed in a shared _skimAndDisburse helper, and surfaced through a FrontendFeeCharged event. The fee is taken from the measured delivered amount, so it stays correct even for fee-on-transfer tokens, and amountOutMin is still checked against the net-of-fee output.