### PR TITLE
Add IPropAMMExactOut extension interface for exact-output swaps

### DIFF
--- a/src/interfaces/IPropAMMExactOut.sol
+++ b/src/interfaces/IPropAMMExactOut.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.35;
 
 import {IPropAMM} from "./IPropAMM.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /// @title IPropAMMExactOut
 /// @notice Optional extension of {IPropAMM} for proprietary AMMs that also
@@ -14,7 +15,19 @@ import {IPropAMM} from "./IPropAMM.sol";
 /// but because the input amount is not known up front it transfers
 /// `amountInMax` and the venue MUST refund the unspent remainder (see
 /// `swapExactOut`).
-interface IPropAMMExactOut is IPropAMM {
+///
+/// Because exact-output is optional, this interface also inherits {IERC165} so
+/// the router and off-chain integrators can detect support at runtime without a
+/// trial swap — e.g. `ERC165Checker.supportsInterface(venue,
+/// type(IPropAMMExactOut).interfaceId)`. A conforming venue MUST report `true`
+/// from `supportsInterface` for `type(IERC165).interfaceId`,
+/// `type(IPropAMM).interfaceId`, and `type(IPropAMMExactOut).interfaceId`.
+/// Note `type(IPropAMMExactOut).interfaceId` covers only the exact-output
+/// selectors declared here (Solidity excludes inherited functions), so it is
+/// distinct from `type(IPropAMM).interfaceId`. Plain exact-input venues that do
+/// not implement ERC165 are still supported: an `ERC165Checker` probe returns
+/// `false` for them rather than reverting.
+interface IPropAMMExactOut is IPropAMM, IERC165 {
     /// @notice Quotes the `tokenIn` amount required to receive an exact
     /// `amountOut` of `tokenOut`.
     /// @dev The exact-output mirror of {IPropAMM-quote}: it inverts the

--- a/src/interfaces/IPropAMMExactOut.sol
+++ b/src/interfaces/IPropAMMExactOut.sol
@@ -52,7 +52,7 @@ interface IPropAMMExactOut is IPropAMM, IERC165 {
     ///  - MUST consume at most `amountInMax` of `tokenIn`, and SHALL revert if
     ///    delivering `amountOut` would require more;
     ///  - MUST refund any unspent `tokenIn` (`amountInMax - amountIn`) to
-    ///    `msg.sender`, the caller that funded the swap.
+    ///    `refundRecipient`.
     /// SHALL revert if the pair is inactive. The `deadline` can safely be
     /// ignored when coming from the Router, since it already does the check.
     /// @param tokenIn The address of the token being sold.
@@ -61,6 +61,7 @@ interface IPropAMMExactOut is IPropAMM, IERC165 {
     /// @param amountInMax The maximum amount of `tokenIn` the caller will spend;
     /// also the amount the caller pushes to the propAMM up front.
     /// @param recipient The address that will receive `tokenOut`.
+    /// @param refundRecipient The address to refund the unspent `tokenIn` to.
     /// @param deadline Unix timestamp after which the swap is no longer valid.
     /// @return amountIn The amount of `tokenIn` actually consumed by the swap.
     function swapExactOut(
@@ -69,6 +70,7 @@ interface IPropAMMExactOut is IPropAMM, IERC165 {
         uint256 amountOut,
         uint256 amountInMax,
         address recipient,
+        address refundRecipient,
         uint256 deadline
     ) external returns (uint256 amountIn);
 }

--- a/src/interfaces/IPropAMMExactOut.sol
+++ b/src/interfaces/IPropAMMExactOut.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IPropAMM} from "./IPropAMM.sol";
+
+/// @title IPropAMMExactOut
+/// @notice Optional extension of {IPropAMM} for proprietary AMMs that also
+/// support exact-output swaps: the caller fixes the exact `amountOut` of
+/// `tokenOut` it wants and a ceiling `amountInMax` on what it will spend.
+/// @dev Inherits the full exact-input surface (`isActive`, `getPairs`, `quote`,
+/// `swap`), the `TokenPair` struct, and the `Swapped` event from {IPropAMM}, so
+/// a venue implementing this interface supports BOTH exact-input and
+/// exact-output. The router uses the same push-payment model as exact-input,
+/// but because the input amount is not known up front it transfers
+/// `amountInMax` and the venue MUST refund the unspent remainder (see
+/// `swapExactOut`).
+interface IPropAMMExactOut is IPropAMM {
+    /// @notice Quotes the `tokenIn` amount required to receive an exact
+    /// `amountOut` of `tokenOut`.
+    /// @dev The exact-output mirror of {IPropAMM-quote}: it inverts the
+    /// known/unknown sides, fixing `amountOut` and returning the required
+    /// `amountIn`. MUST revert if the propAMM is inactive for the pair.
+    /// MUST NOT require a `tokenIn` balance or allowance from the caller.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amountOut The exact amount of `tokenOut` to receive.
+    /// @return amountIn The amount of `tokenIn` the swap would require.
+    function quoteExactOut(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountOut
+    ) external returns (uint256 amountIn);
+
+    /// @notice Swaps as little `tokenIn` as needed to deliver an exact
+    /// `amountOut` of `tokenOut` to `recipient`, spending at most `amountInMax`.
+    /// @dev Push-payment: the caller transfers `amountInMax` of `tokenIn` to the
+    /// propAMM BEFORE this call. The propAMM:
+    ///  - MUST deliver exactly `amountOut` of `tokenOut` to `recipient`;
+    ///  - MUST consume at most `amountInMax` of `tokenIn`, and SHALL revert if
+    ///    delivering `amountOut` would require more;
+    ///  - MUST refund any unspent `tokenIn` (`amountInMax - amountIn`) to
+    ///    `msg.sender`, the caller that funded the swap.
+    /// SHALL revert if the pair is inactive. The `deadline` can safely be
+    /// ignored when coming from the Router, since it already does the check.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amountOut The exact amount of `tokenOut` to deliver to `recipient`.
+    /// @param amountInMax The maximum amount of `tokenIn` the caller will spend;
+    /// also the amount the caller pushes to the propAMM up front.
+    /// @param recipient The address that will receive `tokenOut`.
+    /// @param deadline Unix timestamp after which the swap is no longer valid.
+    /// @return amountIn The amount of `tokenIn` actually consumed by the swap.
+    function swapExactOut(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountOut,
+        uint256 amountInMax,
+        address recipient,
+        uint256 deadline
+    ) external returns (uint256 amountIn);
+}

--- a/test/IPropAMMExactOut.t.sol
+++ b/test/IPropAMMExactOut.t.sol
@@ -2,6 +2,10 @@
 pragma solidity ^0.8.35;
 
 import {Test} from "forge-std/Test.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {ERC165Checker} from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import {IPropAMM} from "../src/interfaces/IPropAMM.sol";
+import {IPropAMMExactOut} from "../src/interfaces/IPropAMMExactOut.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 import {MockPropAMMExactOut} from "./mocks/MockPropAMMExactOut.sol";
 
@@ -111,6 +115,38 @@ contract IPropAMMExactOutTest is Test {
         venue.setActive(false);
         vm.expectRevert(bytes("inactive"));
         venue.quoteExactOut(address(tokenIn), address(tokenOut), 100e18);
+    }
+
+    // --- ERC165 interface detection ----------------------------------------
+
+    function test_supportsInterface_advertisesExpectedIds() public view {
+        assertTrue(venue.supportsInterface(type(IERC165).interfaceId));
+        assertTrue(venue.supportsInterface(type(IPropAMM).interfaceId));
+        assertTrue(venue.supportsInterface(type(IPropAMMExactOut).interfaceId));
+    }
+
+    function test_supportsInterface_rejectsUnknownAndInvalidIds() public view {
+        // A random selector is not advertised.
+        assertFalse(venue.supportsInterface(0xdeadbeef));
+        // 0xffffffff is the ERC165 "invalid" sentinel and must be reported false.
+        assertFalse(venue.supportsInterface(0xffffffff));
+    }
+
+    function test_exactOutId_differsFromBaseId() public pure {
+        // The extension id covers only the exact-output selectors declared in
+        // IPropAMMExactOut, so it is distinct from the exact-input base id.
+        assertTrue(type(IPropAMMExactOut).interfaceId != type(IPropAMM).interfaceId);
+    }
+
+    function test_erc165Checker_detectsExactOutSupport() public view {
+        // The runtime detection path the router uses to opt into exact-output.
+        assertTrue(ERC165Checker.supportsInterface(address(venue), type(IPropAMMExactOut).interfaceId));
+    }
+
+    function test_erc165Checker_returnsFalseForNonErc165Venue() public view {
+        // A plain venue without ERC165 (here, a bare contract) is probed safely:
+        // the checker returns false rather than reverting.
+        assertFalse(ERC165Checker.supportsInterface(address(this), type(IPropAMMExactOut).interfaceId));
     }
 
     // --- inherited exact-input surface (smoke test) ------------------------

--- a/test/IPropAMMExactOut.t.sol
+++ b/test/IPropAMMExactOut.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockPropAMMExactOut} from "./mocks/MockPropAMMExactOut.sol";
+
+/// @notice Exercises a venue implementing {IPropAMMExactOut} to prove the
+/// exact-output contract is implementable as specified: exact delivery, an
+/// `amountInMax` ceiling, refund of the unspent input to `msg.sender`, and an
+/// exact-output quote consistent with execution. This test contract plays the
+/// role of the funding caller (the future router), so `msg.sender` inside the
+/// venue is `address(this)` and the refund lands back here.
+contract IPropAMMExactOutTest is Test {
+    MockPropAMMExactOut internal venue;
+    MockERC20 internal tokenIn;
+    MockERC20 internal tokenOut;
+
+    address internal recipient = address(0xCAFE);
+    uint256 internal constant LIQUIDITY = 1_000_000e18;
+
+    function setUp() public {
+        tokenIn = new MockERC20("TokenIn", "TIN");
+        tokenOut = new MockERC20("TokenOut", "TOUT");
+        // 1 tokenOut costs 2 tokenIn.
+        venue = new MockPropAMMExactOut(2, 1);
+        // Fund the venue with tokenOut liquidity and this caller with tokenIn.
+        tokenOut.mint(address(venue), LIQUIDITY);
+        tokenIn.mint(address(this), LIQUIDITY);
+    }
+
+    function _deadline() private view returns (uint256) {
+        return block.timestamp + 1;
+    }
+
+    // --- swapExactOut ------------------------------------------------------
+
+    function test_swapExactOut_deliversExactOutAndRefundsRemainder() public {
+        uint256 amountOut = 100e18;
+        uint256 required = 200e18; // 100 * 2/1
+        uint256 amountInMax = 250e18; // 50 buffer over the required input
+
+        // Push-payment: caller transfers the ceiling to the venue first.
+        tokenIn.transfer(address(venue), amountInMax);
+        uint256 callerBalAfterPush = tokenIn.balanceOf(address(this));
+
+        uint256 amountIn = venue.swapExactOut(
+            address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, _deadline()
+        );
+
+        // Exactly amountOut delivered to recipient.
+        assertEq(tokenOut.balanceOf(recipient), amountOut);
+        // Reported and actual input consumed equals the required amount.
+        assertEq(amountIn, required);
+        assertEq(tokenIn.balanceOf(address(venue)), required);
+        // Unspent input refunded to msg.sender (this caller).
+        assertEq(tokenIn.balanceOf(address(this)), callerBalAfterPush + (amountInMax - required));
+    }
+
+    function test_swapExactOut_noRefundWhenExactlyFunded() public {
+        uint256 amountOut = 100e18;
+        uint256 required = 200e18;
+
+        tokenIn.transfer(address(venue), required);
+        uint256 callerBalAfterPush = tokenIn.balanceOf(address(this));
+
+        uint256 amountIn = venue.swapExactOut(
+            address(tokenIn), address(tokenOut), amountOut, required, recipient, _deadline()
+        );
+
+        assertEq(amountIn, required);
+        assertEq(tokenOut.balanceOf(recipient), amountOut);
+        // Nothing left to refund.
+        assertEq(tokenIn.balanceOf(address(this)), callerBalAfterPush);
+    }
+
+    function test_swapExactOut_revertsWhenRequiredExceedsMax() public {
+        uint256 amountOut = 100e18; // requires 200e18
+        uint256 amountInMax = 150e18; // below the required input
+
+        tokenIn.transfer(address(venue), amountInMax);
+
+        vm.expectRevert(bytes("exceeds amountInMax"));
+        venue.swapExactOut(address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, _deadline());
+    }
+
+    function test_swapExactOut_revertsWhenInactive() public {
+        venue.setActive(false);
+        tokenIn.transfer(address(venue), 250e18);
+
+        vm.expectRevert(bytes("inactive"));
+        venue.swapExactOut(address(tokenIn), address(tokenOut), 100e18, 250e18, recipient, _deadline());
+    }
+
+    // --- quoteExactOut -----------------------------------------------------
+
+    function test_quoteExactOut_returnsRequiredInput() public view {
+        uint256 amountOut = 100e18;
+        uint256 amountIn = venue.quoteExactOut(address(tokenIn), address(tokenOut), amountOut);
+        assertEq(amountIn, 200e18);
+    }
+
+    function test_quoteExactOut_roundsUp() public {
+        // 1 tokenOut costs 1/3 tokenIn: 10 wei out needs ceil(10/3) = 4 wei in,
+        // never 3 — rounding must favor the venue, not under-charge.
+        MockPropAMMExactOut cheapVenue = new MockPropAMMExactOut(1, 3);
+        assertEq(cheapVenue.quoteExactOut(address(tokenIn), address(tokenOut), 10), 4);
+    }
+
+    function test_quoteExactOut_revertsWhenInactive() public {
+        venue.setActive(false);
+        vm.expectRevert(bytes("inactive"));
+        venue.quoteExactOut(address(tokenIn), address(tokenOut), 100e18);
+    }
+
+    // --- inherited exact-input surface (smoke test) ------------------------
+
+    function test_swap_exactIn_deliversProportionalOutput() public {
+        uint256 amountIn = 200e18;
+        tokenIn.transfer(address(venue), amountIn);
+        uint256 amountOut = venue.swap(
+            address(tokenIn), address(tokenOut), amountIn, 0, recipient, _deadline()
+        );
+        assertEq(amountOut, 100e18);
+        assertEq(tokenOut.balanceOf(recipient), 100e18);
+    }
+}

--- a/test/IPropAMMExactOut.t.sol
+++ b/test/IPropAMMExactOut.t.sol
@@ -11,10 +11,10 @@ import {MockPropAMMExactOut} from "./mocks/MockPropAMMExactOut.sol";
 
 /// @notice Exercises a venue implementing {IPropAMMExactOut} to prove the
 /// exact-output contract is implementable as specified: exact delivery, an
-/// `amountInMax` ceiling, refund of the unspent input to `msg.sender`, and an
-/// exact-output quote consistent with execution. This test contract plays the
-/// role of the funding caller (the future router), so `msg.sender` inside the
-/// venue is `address(this)` and the refund lands back here.
+/// `amountInMax` ceiling, refund of the unspent input to `refundRecipient`,
+/// and an exact-output quote consistent with execution. This test contract
+/// plays the role of the funding caller (the future router) and names itself
+/// as `refundRecipient`, so the refund lands back here.
 contract IPropAMMExactOutTest is Test {
     MockPropAMMExactOut internal venue;
     MockERC20 internal tokenIn;
@@ -49,7 +49,7 @@ contract IPropAMMExactOutTest is Test {
         uint256 callerBalAfterPush = tokenIn.balanceOf(address(this));
 
         uint256 amountIn = venue.swapExactOut(
-            address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, _deadline()
+            address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, address(this), _deadline()
         );
 
         // Exactly amountOut delivered to recipient.
@@ -57,8 +57,24 @@ contract IPropAMMExactOutTest is Test {
         // Reported and actual input consumed equals the required amount.
         assertEq(amountIn, required);
         assertEq(tokenIn.balanceOf(address(venue)), required);
-        // Unspent input refunded to msg.sender (this caller).
+        // Unspent input refunded to refundRecipient (this caller).
         assertEq(tokenIn.balanceOf(address(this)), callerBalAfterPush + (amountInMax - required));
+    }
+
+    function test_swapExactOut_refundsToDistinctRefundRecipient() public {
+        uint256 amountOut = 100e18;
+        uint256 required = 200e18; // 100 * 2/1
+        uint256 amountInMax = 250e18; // 50 buffer over the required input
+        address refundRecipient = address(0xBEEF);
+
+        tokenIn.transfer(address(venue), amountInMax);
+
+        venue.swapExactOut(
+            address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, refundRecipient, _deadline()
+        );
+
+        // The refund goes to the named refundRecipient, not the caller.
+        assertEq(tokenIn.balanceOf(refundRecipient), amountInMax - required);
     }
 
     function test_swapExactOut_noRefundWhenExactlyFunded() public {
@@ -69,7 +85,7 @@ contract IPropAMMExactOutTest is Test {
         uint256 callerBalAfterPush = tokenIn.balanceOf(address(this));
 
         uint256 amountIn = venue.swapExactOut(
-            address(tokenIn), address(tokenOut), amountOut, required, recipient, _deadline()
+            address(tokenIn), address(tokenOut), amountOut, required, recipient, address(this), _deadline()
         );
 
         assertEq(amountIn, required);
@@ -85,7 +101,9 @@ contract IPropAMMExactOutTest is Test {
         tokenIn.transfer(address(venue), amountInMax);
 
         vm.expectRevert(bytes("exceeds amountInMax"));
-        venue.swapExactOut(address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, _deadline());
+        venue.swapExactOut(
+            address(tokenIn), address(tokenOut), amountOut, amountInMax, recipient, address(this), _deadline()
+        );
     }
 
     function test_swapExactOut_revertsWhenInactive() public {
@@ -93,7 +111,7 @@ contract IPropAMMExactOutTest is Test {
         tokenIn.transfer(address(venue), 250e18);
 
         vm.expectRevert(bytes("inactive"));
-        venue.swapExactOut(address(tokenIn), address(tokenOut), 100e18, 250e18, recipient, _deadline());
+        venue.swapExactOut(address(tokenIn), address(tokenOut), 100e18, 250e18, recipient, address(this), _deadline());
     }
 
     // --- quoteExactOut -----------------------------------------------------

--- a/test/mocks/MockPropAMMExactOut.sol
+++ b/test/mocks/MockPropAMMExactOut.sol
@@ -87,6 +87,7 @@ contract MockPropAMMExactOut is IPropAMMExactOut {
         uint256 amountOut,
         uint256 amountInMax,
         address recipient,
+        address refundRecipient,
         uint256
     ) external returns (uint256 amountIn) {
         require(active, "inactive");
@@ -95,10 +96,10 @@ contract MockPropAMMExactOut is IPropAMMExactOut {
 
         // Deliver exactly amountOut from the venue's liquidity.
         IERC20(tokenOut).safeTransfer(recipient, amountOut);
-        // Refund the unspent input pushed up front to the funding caller.
+        // Refund the unspent input pushed up front to the refund recipient.
         uint256 refund = amountInMax - amountIn;
         if (refund > 0) {
-            IERC20(tokenIn).safeTransfer(msg.sender, refund);
+            IERC20(tokenIn).safeTransfer(refundRecipient, refund);
         }
         emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient);
     }

--- a/test/mocks/MockPropAMMExactOut.sol
+++ b/test/mocks/MockPropAMMExactOut.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.35;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IPropAMM} from "../../src/interfaces/IPropAMM.sol";
 import {IPropAMMExactOut} from "../../src/interfaces/IPropAMMExactOut.sol";
 
@@ -43,6 +44,13 @@ contract MockPropAMMExactOut is IPropAMMExactOut {
 
     function getPairs() external view returns (IPropAMM.TokenPair[] memory) {
         return _pairs;
+    }
+
+    /// @notice ERC165 detection: advertises ERC165 itself, the exact-input base
+    /// {IPropAMM}, and the exact-output extension {IPropAMMExactOut}.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IPropAMM).interfaceId
+            || interfaceId == type(IPropAMMExactOut).interfaceId;
     }
 
     function quote(address, address, uint256 amountIn) external view returns (uint256 amountOut) {

--- a/test/mocks/MockPropAMMExactOut.sol
+++ b/test/mocks/MockPropAMMExactOut.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IPropAMM} from "../../src/interfaces/IPropAMM.sol";
+import {IPropAMMExactOut} from "../../src/interfaces/IPropAMMExactOut.sol";
+
+/// @notice A minimal venue implementing the full {IPropAMMExactOut} surface
+/// (inherited exact-input + exact-output) against a fixed linear price, used to
+/// prove the interface is implementable as specified. Price is expressed as a
+/// ratio: delivering `amountOut` costs `ceil(amountOut * priceNum / priceDen)`
+/// of `tokenIn`; selling `amountIn` yields `amountIn * priceDen / priceNum`.
+/// The venue is funded with `tokenOut` liquidity ahead of time and follows the
+/// push-payment model: the caller transfers the input to this contract before
+/// calling `swap` / `swapExactOut`.
+contract MockPropAMMExactOut is IPropAMMExactOut {
+    using SafeERC20 for IERC20;
+
+    uint256 public priceNum;
+    uint256 public priceDen;
+    bool public active = true;
+
+    IPropAMM.TokenPair[] private _pairs;
+
+    constructor(uint256 priceNum_, uint256 priceDen_) {
+        priceNum = priceNum_;
+        priceDen = priceDen_;
+    }
+
+    function setActive(bool active_) external {
+        active = active_;
+    }
+
+    function addPair(address token0, address token1) external {
+        _pairs.push(IPropAMM.TokenPair(token0, token1));
+    }
+
+    function isActive(address, address) external view returns (bool) {
+        return active;
+    }
+
+    function getPairs() external view returns (IPropAMM.TokenPair[] memory) {
+        return _pairs;
+    }
+
+    function quote(address, address, uint256 amountIn) external view returns (uint256 amountOut) {
+        require(active, "inactive");
+        amountOut = amountIn * priceDen / priceNum;
+    }
+
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address recipient,
+        uint256
+    ) external returns (uint256 amountOut) {
+        require(active, "inactive");
+        amountOut = amountIn * priceDen / priceNum;
+        require(amountOut >= minAmountOut, "slippage");
+        IERC20(tokenOut).safeTransfer(recipient, amountOut);
+        emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient);
+    }
+
+    // --- exact-output ------------------------------------------------------
+
+    function quoteExactOut(address, address, uint256 amountOut) external view returns (uint256 amountIn) {
+        require(active, "inactive");
+        // Round up so the venue is never under-charged for the exact output.
+        amountIn = Math.ceilDiv(amountOut * priceNum, priceDen);
+    }
+
+    function swapExactOut(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountOut,
+        uint256 amountInMax,
+        address recipient,
+        uint256
+    ) external returns (uint256 amountIn) {
+        require(active, "inactive");
+        amountIn = Math.ceilDiv(amountOut * priceNum, priceDen);
+        require(amountIn <= amountInMax, "exceeds amountInMax");
+
+        // Deliver exactly amountOut from the venue's liquidity.
+        IERC20(tokenOut).safeTransfer(recipient, amountOut);
+        // Refund the unspent input pushed up front to the funding caller.
+        uint256 refund = amountInMax - amountIn;
+        if (refund > 0) {
+            IERC20(tokenIn).safeTransfer(msg.sender, refund);
+        }
+        emit Swapped(msg.sender, tokenIn, tokenOut, amountIn, amountOut, recipient);
+    }
+}


### PR DESCRIPTION
Extends the frozen IPropAMM venue interface with exact-output variants:

- quoteExactOut(tokenIn, tokenOut, amountOut) -> amountIn: the exact-output mirror of quote(), returning the tokenIn required for a fixed amountOut.
- swapExactOut(tokenIn, tokenOut, amountOut, amountInMax, recipient, deadline) -> amountIn: push-payment model where the caller transfers amountInMax up front, the venue delivers exactly amountOut, consumes <= amountInMax (reverts otherwise), and refunds the unspent tokenIn to msg.sender (mirrors UniV3Router.swapExactOut).

A venue implementing IPropAMMExactOut therefore supports both exact-input and exact-output. IPropAMM (frozen V1) is inherited, not modified. Router exactOut entrypoints are intentionally out of scope (a separate later task).

Adds MockPropAMMExactOut and a test suite (8 tests) proving the contract is implementable: exact delivery, the amountInMax ceiling, refund-to-msg.sender, ceil-rounded quoting, and inactive-pair reverts.