### PR TITLE
chore: add clarification on `getPair()` expected result

### DIFF
--- a/src/interfaces/IPropAMM.sol
+++ b/src/interfaces/IPropAMM.sol
@@ -28,6 +28,7 @@ interface IPropAMM {
     );
 
     /// @notice A token pair a propAMM supports.
+    /// @dev Tokens are canonically ordered: `token0 < token1`.
     struct TokenPair {
         address token0;
         address token1;

--- a/src/interfaces/IPropAMM.sol
+++ b/src/interfaces/IPropAMM.sol
@@ -46,8 +46,9 @@ interface IPropAMM {
         address tokenOut
     ) external view returns (bool active);
 
-    /// @notice Returns all token pairs the propAMM support, both active and inactive.
-    /// @dev Advisory, for off-chain discovery; the router does not call this on
+    /// @notice Returns all token pairs the propAMM supports, both active and inactive.
+    /// @dev Each pair MUST appear exactly once, with `token0 < token1`.
+    /// Advisory, for off-chain discovery; the router does not call this on
     /// its swap path.
     /// @return pairs The supported pairs.
     function getPairs() external view returns (TokenPair[] memory pairs);


### PR DESCRIPTION
We didn't specify `getPair()` expected result, for instance, if it should return both USDC/WETH and WETH/USDC or only one. We clarify this by requiring deduplicated entries with a specific ordering