### PR TITLE
fix(sdk): null RPC error, Arc snapshots, typed swap errors, tests

### DIFF
--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -94,16 +94,21 @@ impl ContractClient {
             from: self.signer_address(),
             ..Default::default()
         };
-        let state = overrides.state.clone().unwrap_or_default();
-        let block = overrides.block.clone().unwrap_or_default();
+        // Borrow the caller's override sets directly — cloning would deep-copy
+        // the merged slot-diff map on every call. Empty defaults are cheap
+        // (no heap allocation) and only used when an override is absent.
+        let default_state = StateOverrideSet::default();
+        let default_block = BlockOverrideSet::default();
+        let state = overrides.state.as_ref().unwrap_or(&default_state);
+        let block = overrides.block.as_ref().unwrap_or(&default_block);
 
         let raw = call_with_overrides(
             &self.client,
             to,
             calldata.into(),
             tx_overrides,
-            &state,
-            &block,
+            state,
+            block,
         )
         .await
         .map_err(parse_call_error)?;

--- a/sdk/rust/src/common/helpers.rs
+++ b/sdk/rust/src/common/helpers.rs
@@ -94,3 +94,90 @@ pub fn parse_ether(amount: &str) -> Result<U256> {
 pub fn format_ether(value: U256) -> String {
     format_units(value, 18)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_slippage_shaves_bps_and_floors_in_the_users_favor() {
+        // 0.5% off 1_000_000 -> 5_000 fee.
+        assert_eq!(
+            apply_slippage(U256::from(1_000_000u64), 50).unwrap(),
+            U256::from(995_000u64)
+        );
+        // 0 bps is a no-op; the full denominator zeroes the amount.
+        let amount = U256::from(123_456u64);
+        assert_eq!(apply_slippage(amount, 0).unwrap(), amount);
+        assert_eq!(apply_slippage(amount, 10_000).unwrap(), U256::zero());
+        // The fee floors, so the min-out rounds UP (stricter for the user):
+        // 10_001 * 1bps = 1.0001 -> fee 1 -> 10_000.
+        assert_eq!(
+            apply_slippage(U256::from(10_001u64), 1).unwrap(),
+            U256::from(10_000u64)
+        );
+    }
+
+    #[test]
+    fn apply_slippage_rejects_bps_above_denominator() {
+        assert!(apply_slippage(U256::from(1u64), 10_001).is_err());
+    }
+
+    #[test]
+    fn apply_slippage_does_not_overflow_for_huge_amounts() {
+        // full_mul widens to U512, so amounts near U256::MAX are safe.
+        let out = apply_slippage(U256::MAX, 100).unwrap();
+        assert!(out < U256::MAX && out > U256::zero());
+    }
+
+    #[test]
+    fn parse_units_handles_integers_fractions_and_leading_zeros() {
+        assert_eq!(parse_units("1.5", 6).unwrap(), U256::from(1_500_000u64));
+        assert_eq!(parse_units("1", 6).unwrap(), U256::from(1_000_000u64));
+        assert_eq!(parse_units("0.0015", 6).unwrap(), U256::from(1_500u64));
+        assert_eq!(parse_ether("1").unwrap(), U256::exp10(18));
+    }
+
+    #[test]
+    fn parse_units_rejects_excess_precision() {
+        assert!(parse_units("1.9999995", 6).is_err());
+    }
+
+    #[test]
+    fn format_units_trims_zeros_and_round_trips_parse_units() {
+        assert_eq!(format_units(U256::from(1_500_000u64), 6), "1.5");
+        assert_eq!(format_units(U256::from(1_000_000u64), 6), "1");
+        assert_eq!(format_units(U256::from(1_500u64), 6), "0.0015");
+        assert_eq!(format_units(U256::zero(), 6), "0");
+        assert_eq!(format_ether(U256::exp10(18)), "1");
+        let value = parse_units("1234.567", 6).unwrap();
+        assert_eq!(format_units(value, 6), "1234.567");
+    }
+
+    #[test]
+    fn parse_address_validates_length_and_hex() {
+        let mut bytes = [0u8; 20];
+        bytes[19] = 1;
+        let one = Address::from_slice(&bytes);
+        assert_eq!(
+            parse_address("0x0000000000000000000000000000000000000001").unwrap(),
+            one
+        );
+        // The 0x prefix is optional.
+        assert_eq!(
+            parse_address("0000000000000000000000000000000000000001").unwrap(),
+            one
+        );
+        // Wrong length and non-hex are rejected.
+        assert!(parse_address("0x1234").is_err());
+        assert!(parse_address("0xZZ00000000000000000000000000000000000001").is_err());
+    }
+
+    #[test]
+    fn deadline_in_returns_future_unix_seconds() {
+        let base = deadline_in(0);
+        // Well past the 2023 epoch, and a positive offset only grows it.
+        assert!(base >= U256::from(1_700_000_000u64));
+        assert!(deadline_in(1_000) > base);
+    }
+}

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -45,10 +45,6 @@ pub enum Error {
     /// Invalid caller-supplied input (addresses, fee bounds, keys, URLs, ...).
     #[error("invalid input: {0}")]
     InvalidInput(String),
-
-    /// Anything else.
-    #[error("{0}")]
-    Other(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/sdk/rust/src/error.rs
+++ b/sdk/rust/src/error.rs
@@ -1,4 +1,7 @@
+use ethrex_common::H256;
 use thiserror::Error;
+
+use crate::client::TransactionReceipt;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -13,6 +16,19 @@ pub enum Error {
         message: String,
         data: Option<Vec<u8>>,
     },
+
+    /// A mined transaction reverted on-chain. Carries the receipt so callers
+    /// can inspect status, gas, and logs without another RPC round-trip.
+    #[error("transaction {hash:#x} reverted")]
+    TransactionReverted {
+        hash: H256,
+        receipt: Box<TransactionReceipt>,
+    },
+
+    /// A mined, successful transaction emitted no expected event (e.g. a swap
+    /// with no `Swapped` log — usually the wrong router address or ABI drift).
+    #[error("transaction {hash:#x} emitted no {event} event")]
+    MissingEvent { hash: H256, event: &'static str },
 
     /// ABI encoding/decoding failure.
     #[error("abi error: {0}")]

--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -247,11 +247,22 @@ impl OverridesSource for OverridesRpcSource {
             .json()
             .await
             .map_err(|e| Error::Overrides(format!("overrides RPC response is not JSON: {e}")))?;
-        if let Some(error) = body.get("error") {
-            return Err(Error::Overrides(format!("overrides RPC error: {error}")));
-        }
-        parse_overrides_message(body.get("result").unwrap_or(&Value::Null))
+        parse_rpc_response(&body)
     }
+}
+
+/// Parse a `titan_getPammStateOverrides` JSON-RPC response body into a snapshot.
+///
+/// A present-but-null `"error"` is treated as success: many JSON-RPC servers
+/// send `{"result": {...}, "error": null}`, and the field's mere presence must
+/// not be read as a failure (this mirrors the reference SDK's truthiness check
+/// — `serde_json` returns `Some(Value::Null)`, not `None`, for an explicit
+/// null).
+fn parse_rpc_response(body: &Value) -> Result<OverridesSnapshot> {
+    if let Some(error) = body.get("error").filter(|error| !error.is_null()) {
+        return Err(Error::Overrides(format!("overrides RPC error: {error}")));
+    }
+    parse_overrides_message(body.get("result").unwrap_or(&Value::Null))
 }
 
 /// Configuration for [`OverridesWsSource`].
@@ -485,4 +496,40 @@ async fn idle_expired(state: &WsState, idle_timeout: Duration) -> bool {
         shared.has_frame = false;
     }
     expired
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_response_treats_null_error_as_success() {
+        // Servers that send `"error": null` alongside a result must not be read
+        // as failures — the field is present but null.
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": null,
+            "result": { "blockNumber": 100 },
+        });
+        let snapshot = parse_rpc_response(&body).expect("null error is success");
+        assert_eq!(snapshot.block_number, Some(100));
+    }
+
+    #[test]
+    fn rpc_response_parses_result_when_error_key_absent() {
+        let body = serde_json::json!({ "result": { "blockNumber": 5 } });
+        let snapshot = parse_rpc_response(&body).expect("missing error key is success");
+        assert_eq!(snapshot.block_number, Some(5));
+        assert!(snapshot.per_pamm.is_empty());
+    }
+
+    #[test]
+    fn rpc_response_surfaces_a_real_error_object() {
+        let body = serde_json::json!({
+            "error": { "code": -32000, "message": "boom" },
+        });
+        let err = parse_rpc_response(&body).expect_err("non-null error must fail");
+        assert!(matches!(err, Error::Overrides(_)));
+    }
 }

--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -542,4 +542,139 @@ mod tests {
         let err = parse_rpc_response(&body).expect_err("non-null error must fail");
         assert!(matches!(err, Error::Overrides(_)));
     }
+
+    fn slot(n: u64) -> H256 {
+        H256(U256::from(n).to_big_endian())
+    }
+
+    fn snapshot_with(
+        pamm: Address,
+        contract: Address,
+        slot: H256,
+        value: U256,
+        block_number: Option<u64>,
+    ) -> OverridesSnapshot {
+        let mut slots = SlotDiffs::new();
+        slots.insert(slot, value);
+        let mut contracts = ContractDiffs::new();
+        contracts.insert(contract, slots);
+        let mut per_pamm = HashMap::new();
+        per_pamm.insert(pamm, contracts);
+        OverridesSnapshot {
+            block_number,
+            timestamp_ns: None,
+            per_pamm,
+        }
+    }
+
+    #[test]
+    fn parse_word_accepts_padded_and_unpadded_hex() {
+        assert_eq!(parse_word("0x2a"), Some(U256::from(42u64)));
+        assert_eq!(parse_word("0x1"), Some(U256::from(1u64)));
+        assert_eq!(parse_word("2a"), None); // missing 0x prefix
+        assert_eq!(parse_word("0xzz"), None); // non-hex
+    }
+
+    #[test]
+    fn parse_block_number_accepts_int_hex_and_decimal_forms() {
+        assert_eq!(parse_block_number(&serde_json::json!(100)), Some(100));
+        assert_eq!(parse_block_number(&serde_json::json!("0x64")), Some(100));
+        assert_eq!(parse_block_number(&serde_json::json!("100")), Some(100));
+        assert_eq!(parse_block_number(&serde_json::json!("oops")), None);
+    }
+
+    #[test]
+    fn parse_overrides_message_extracts_diffs_and_skips_metadata() {
+        let pamm = "0x0000000000000000000000000000000000000abc";
+        let contract = "0x0000000000000000000000000000000000000011";
+        let raw = format!(
+            r#"{{
+                "blockNumber": 24285034,
+                "timestamp": 1700000000000000000,
+                "slot": "meta-key-ignored",
+                "{pamm}": {{ "stateOverride": {{
+                    "{contract}": {{ "stateDiff": {{ "0x1": "0x2a" }} }}
+                }} }}
+            }}"#
+        );
+        let message: Value = serde_json::from_str(&raw).unwrap();
+        let snapshot = parse_overrides_message(&message).unwrap();
+
+        assert_eq!(snapshot.block_number, Some(24_285_034));
+        assert_eq!(snapshot.timestamp_ns, Some(1_700_000_000_000_000_000));
+        assert_eq!(snapshot.per_pamm.len(), 1);
+        let pamm = parse_address(pamm).unwrap();
+        let contract = parse_address(contract).unwrap();
+        assert_eq!(
+            snapshot.per_pamm[&pamm][&contract].get(&slot(1)),
+            Some(&U256::from(42u64))
+        );
+    }
+
+    #[test]
+    fn parse_overrides_message_drops_empty_and_invalid_entries() {
+        let raw = r#"{
+            "not-an-address": { "stateOverride": {} },
+            "0x00000000000000000000000000000000000000ff": {
+                "stateOverride": { "0x0000000000000000000000000000000000000011": { "stateDiff": {} } }
+            }
+        }"#;
+        let message: Value = serde_json::from_str(raw).unwrap();
+        assert!(
+            parse_overrides_message(&message)
+                .unwrap()
+                .per_pamm
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn to_state_override_zeroes_the_bebop_default_slot_when_absent() {
+        let pamm = parse_address("0x0000000000000000000000000000000000000abc").unwrap();
+        let contract = parse_address("0x0000000000000000000000000000000000000011").unwrap();
+        let snapshot = snapshot_with(pamm, contract, slot(7), U256::from(99u64), Some(1));
+
+        let set = to_state_override(&snapshot, &ToStateOverrideOptions::default());
+        // The real diff survives...
+        assert_eq!(
+            set.0[&contract].state_diff.get(&slot(7)),
+            Some(&U256::from(99u64))
+        );
+        // ...and the Bebop registry slot is zeroed because no Bebop entry exists,
+        // so a stale on-chain Bebop price can't win a quote it could never fill.
+        assert_eq!(
+            set.0[&BEBOP].state_diff.get(&BEBOP_DEFAULT_SLOT),
+            Some(&U256::zero())
+        );
+    }
+
+    #[test]
+    fn to_state_override_can_skip_the_bebop_default() {
+        let pamm = parse_address("0x0000000000000000000000000000000000000abc").unwrap();
+        let contract = parse_address("0x0000000000000000000000000000000000000011").unwrap();
+        let snapshot = snapshot_with(pamm, contract, slot(7), U256::from(99u64), None);
+
+        let set = to_state_override(
+            &snapshot,
+            &ToStateOverrideOptions {
+                pamms: None,
+                skip_bebop_default: true,
+            },
+        );
+        assert!(!set.0.contains_key(&BEBOP));
+    }
+
+    #[test]
+    fn to_state_override_keeps_real_bebop_diffs_without_injecting_default() {
+        let contract = parse_address("0x0000000000000000000000000000000000000011").unwrap();
+        // pAMM IS Bebop, so the default-slot injection is skipped.
+        let snapshot = snapshot_with(BEBOP, contract, slot(7), U256::from(99u64), None);
+
+        let set = to_state_override(&snapshot, &ToStateOverrideOptions::default());
+        assert_eq!(
+            set.0[&contract].state_diff.get(&slot(7)),
+            Some(&U256::from(99u64))
+        );
+        assert!(!set.0.contains_key(&BEBOP));
+    }
 }

--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -265,7 +265,12 @@ fn parse_rpc_response(body: &Value) -> Result<OverridesSnapshot> {
     if let Some(error) = body.get("error").filter(|error| !error.is_null()) {
         return Err(Error::Overrides(format!("overrides RPC error: {error}")));
     }
-    parse_overrides_message(body.get("result").unwrap_or(&Value::Null))
+    match body.get("result") {
+        Some(result) if !result.is_null() => parse_overrides_message(result),
+        _ => Err(Error::Overrides(
+            "overrides RPC response had neither a result nor an error".into(),
+        )),
+    }
 }
 
 /// Configuration for [`OverridesWsSource`].
@@ -543,6 +548,17 @@ mod tests {
         });
         let err = parse_rpc_response(&body).expect_err("non-null error must fail");
         assert!(matches!(err, Error::Overrides(_)));
+    }
+
+    #[test]
+    fn rpc_response_errors_clearly_without_result_or_error() {
+        let body = serde_json::json!({ "jsonrpc": "2.0", "id": 1 });
+        match parse_rpc_response(&body) {
+            Err(Error::Overrides(msg)) => {
+                assert!(msg.contains("neither a result nor an error"), "got: {msg}")
+            }
+            other => panic!("expected an Overrides error, got {other:?}"),
+        }
     }
 
     fn slot(n: u64) -> H256 {

--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -368,26 +368,28 @@ impl OverridesWsSource {
 #[async_trait]
 impl OverridesSource for OverridesWsSource {
     async fn get_overrides(&self) -> Result<Arc<OverridesSnapshot>> {
-        // Warm path: a single lock acquisition. Record demand, and if a fresh
-        // frame is already buffered hand out its Arc immediately. Otherwise
-        // (re)spawn the read loop under the same lock — `tokio::spawn` is
-        // synchronous, so the spawn decision can't race a concurrent idle
-        // teardown.
+        // Warm path: a single lock acquisition. Record demand, ensure the read
+        // loop is alive (respawn if it died — checked even when a frame is
+        // buffered, so an unexpectedly-dead loop can't leave us serving a
+        // forever-stale snapshot), then hand out a buffered frame's Arc
+        // immediately if present. Spawning under the lock is safe: `tokio::spawn`
+        // is synchronous, so it can neither race a concurrent idle teardown nor
+        // deadlock on the lock the spawned loop will later take.
         {
             let mut shared = self.state.shared.lock().await;
             if shared.closed {
                 return Err(Error::Overrides("overrides source is closed".into()));
             }
             shared.last_use = Some(Instant::now());
-            if shared.has_frame {
-                return Ok(shared.snapshot.clone());
-            }
             let running = shared.task.as_ref().is_some_and(|t| !t.is_finished());
             if !running {
                 shared.task = Some(tokio::spawn(run_ws_loop(
                     self.state.clone(),
                     self.config.clone(),
                 )));
+            }
+            if shared.has_frame {
+                return Ok(shared.snapshot.clone());
             }
         }
 

--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -66,9 +66,12 @@ pub struct OverridesSnapshot {
 }
 
 /// Anything quotes can pull override snapshots from.
+///
+/// Snapshots are handed out behind an [`Arc`] so the hot quote path clones a
+/// pointer rather than deep-copying the nested per-pAMM slot maps.
 #[async_trait]
 pub trait OverridesSource: Send + Sync {
-    async fn get_overrides(&self) -> Result<OverridesSnapshot>;
+    async fn get_overrides(&self) -> Result<Arc<OverridesSnapshot>>;
     /// Immediate, permanent teardown. Default: no-op.
     fn close(&self) {}
 }
@@ -222,7 +225,7 @@ impl OverridesRpcSource {
 
 #[async_trait]
 impl OverridesSource for OverridesRpcSource {
-    async fn get_overrides(&self) -> Result<OverridesSnapshot> {
+    async fn get_overrides(&self) -> Result<Arc<OverridesSnapshot>> {
         let response = self
             .client
             .post(&self.url)
@@ -247,7 +250,7 @@ impl OverridesSource for OverridesRpcSource {
             .json()
             .await
             .map_err(|e| Error::Overrides(format!("overrides RPC response is not JSON: {e}")))?;
-        parse_rpc_response(&body)
+        parse_rpc_response(&body).map(Arc::new)
     }
 }
 
@@ -304,7 +307,7 @@ pub struct OverridesWsSource {
 
 #[derive(Default)]
 struct WsShared {
-    snapshot: OverridesSnapshot,
+    snapshot: Arc<OverridesSnapshot>,
     has_frame: bool,
     closed: bool,
     last_use: Option<Instant>,
@@ -334,7 +337,10 @@ impl OverridesWsSource {
         }
     }
 
-    async fn wait_for_snapshot(&self, deadline: tokio::time::Instant) -> Result<OverridesSnapshot> {
+    async fn wait_for_snapshot(
+        &self,
+        deadline: tokio::time::Instant,
+    ) -> Result<Arc<OverridesSnapshot>> {
         loop {
             // Register for notification BEFORE checking state, so a frame
             // landing in between can't be missed.
@@ -345,6 +351,7 @@ impl OverridesWsSource {
                     return Err(Error::Overrides("overrides source is closed".into()));
                 }
                 if shared.has_frame {
+                    // Arc clone: one refcount bump, not a deep map copy.
                     return Ok(shared.snapshot.clone());
                 }
             }
@@ -356,36 +363,33 @@ impl OverridesWsSource {
             }
         }
     }
-
-    /// Spawn the read loop if it isn't running. Must be called with demand
-    /// registered (`last_use` set) so the loop doesn't idle out immediately.
-    async fn ensure_running(&self) -> Result<()> {
-        let mut shared = self.state.shared.lock().await;
-        if shared.closed {
-            return Err(Error::Overrides("overrides source is closed".into()));
-        }
-        let running = shared.task.as_ref().is_some_and(|t| !t.is_finished());
-        if !running {
-            shared.task = Some(tokio::spawn(run_ws_loop(
-                self.state.clone(),
-                self.config.clone(),
-            )));
-        }
-        Ok(())
-    }
 }
 
 #[async_trait]
 impl OverridesSource for OverridesWsSource {
-    async fn get_overrides(&self) -> Result<OverridesSnapshot> {
+    async fn get_overrides(&self) -> Result<Arc<OverridesSnapshot>> {
+        // Warm path: a single lock acquisition. Record demand, and if a fresh
+        // frame is already buffered hand out its Arc immediately. Otherwise
+        // (re)spawn the read loop under the same lock — `tokio::spawn` is
+        // synchronous, so the spawn decision can't race a concurrent idle
+        // teardown.
         {
             let mut shared = self.state.shared.lock().await;
             if shared.closed {
                 return Err(Error::Overrides("overrides source is closed".into()));
             }
             shared.last_use = Some(Instant::now());
+            if shared.has_frame {
+                return Ok(shared.snapshot.clone());
+            }
+            let running = shared.task.as_ref().is_some_and(|t| !t.is_finished());
+            if !running {
+                shared.task = Some(tokio::spawn(run_ws_loop(
+                    self.state.clone(),
+                    self.config.clone(),
+                )));
+            }
         }
-        self.ensure_running().await?;
 
         let deadline = tokio::time::Instant::now() + self.config.first_frame_timeout;
         self.state.waiters.fetch_add(1, Ordering::SeqCst);
@@ -457,14 +461,20 @@ async fn handle_frame(state: &WsState, text: &str) {
     };
 
     let mut shared = state.shared.lock().await;
-    // A frame only carries the pAMMs it updates; entries for other pAMMs
-    // stay cached from earlier frames.
-    shared.snapshot.per_pamm.extend(frame.per_pamm);
-    if frame.block_number.is_some() {
-        shared.snapshot.block_number = frame.block_number;
-    }
-    if frame.timestamp_ns.is_some() {
-        shared.snapshot.timestamp_ns = frame.timestamp_ns;
+    {
+        // `make_mut` clones only when a reader still holds the Arc; readers keep
+        // it only transiently (across one quote), so frames usually mutate in
+        // place rather than deep-copying.
+        let snapshot = Arc::make_mut(&mut shared.snapshot);
+        // A frame only carries the pAMMs it updates; entries for other pAMMs
+        // stay cached from earlier frames.
+        snapshot.per_pamm.extend(frame.per_pamm);
+        if frame.block_number.is_some() {
+            snapshot.block_number = frame.block_number;
+        }
+        if frame.timestamp_ns.is_some() {
+            snapshot.timestamp_ns = frame.timestamp_ns;
+        }
     }
     shared.has_frame = true;
     drop(shared);

--- a/sdk/rust/src/router/abi.rs
+++ b/sdk/rust/src/router/abi.rs
@@ -237,6 +237,85 @@ fn format_value(value: &Value) -> String {
 mod tests {
     use super::*;
 
+    fn u256_word(n: u64) -> [u8; 32] {
+        U256::from(n).to_big_endian()
+    }
+
+    fn address_word(address: Address) -> [u8; 32] {
+        let mut word = [0u8; 32];
+        word[12..].copy_from_slice(address.as_bytes());
+        word
+    }
+
+    fn address_with_last_byte(byte: u8) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[19] = byte;
+        Address::from_slice(&bytes)
+    }
+
+    #[test]
+    fn decode_values_handles_narrow_integer_widths() {
+        // ethrex maps every uintN to a 256-bit Value::Uint; pin that for the
+        // uint24/uint16 return + error decodes the SDK relies on.
+        let values = decode_values("uint24", &u256_word(42)).unwrap();
+        assert_eq!(as_u256(&values[0]).unwrap(), U256::from(42u64));
+
+        let mut data = u256_word(7).to_vec();
+        data.extend_from_slice(&u256_word(16));
+        let values = decode_values("uint16,uint16", &data).unwrap();
+        assert_eq!(as_u256(&values[0]).unwrap(), U256::from(7u64));
+        assert_eq!(as_u256(&values[1]).unwrap(), U256::from(16u64));
+    }
+
+    #[test]
+    fn decode_error_names_narrow_width_custom_errors() {
+        let mut fallback = keccak("InvalidFallbackFee(uint24)".as_bytes()).as_bytes()[..4].to_vec();
+        fallback.extend_from_slice(&u256_word(3000));
+        assert_eq!(
+            decode_error(&fallback).as_deref(),
+            Some("InvalidFallbackFee(3000)")
+        );
+
+        let mut fee = keccak("FeeBpsTooHigh(uint16,uint16)".as_bytes()).as_bytes()[..4].to_vec();
+        fee.extend_from_slice(&u256_word(150));
+        fee.extend_from_slice(&u256_word(100));
+        assert_eq!(
+            decode_error(&fee).as_deref(),
+            Some("FeeBpsTooHigh(150, 100)")
+        );
+    }
+
+    #[test]
+    fn decode_error_returns_none_for_unknown_selector() {
+        assert_eq!(decode_error(&[0xde, 0xad, 0xbe, 0xef]), None);
+    }
+
+    #[test]
+    fn swapped_event_data_decodes_in_the_layout_wait_for_swap_expects() {
+        // Swapped data fields (after the 3 indexed leading addresses):
+        // (amountIn, amountOut, recipient, marketMaker).
+        let recipient = address_with_last_byte(0xaa);
+        let market_maker = address_with_last_byte(0xbb);
+        let mut data = u256_word(1000).to_vec();
+        data.extend_from_slice(&u256_word(950));
+        data.extend_from_slice(&address_word(recipient));
+        data.extend_from_slice(&address_word(market_maker));
+
+        let values = decode_values("uint256,uint256,address,address", &data).unwrap();
+        assert_eq!(as_u256(&values[0]).unwrap(), U256::from(1000u64));
+        assert_eq!(as_u256(&values[1]).unwrap(), U256::from(950u64));
+        assert_eq!(as_address(&values[2]).unwrap(), recipient);
+        assert_eq!(as_address(&values[3]).unwrap(), market_maker);
+    }
+
+    #[test]
+    fn topic_as_address_reads_the_low_20_bytes() {
+        // FrontendFeeCharged's feeRecipient arrives as an indexed topic.
+        let recipient = address_with_last_byte(0xcd);
+        let topic = H256(address_word(recipient));
+        assert_eq!(topic_as_address(&topic), recipient);
+    }
+
     /// Selectors verified against `forge inspect PropAMMRouter methodIdentifiers`.
     /// Guards the signature strings — with runtime ABI, a typo here is the
     /// only thing the compiler can't catch.

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -436,7 +436,10 @@ impl PropAmmRouter {
     pub async fn wait_for_swap(&self, hash: H256) -> Result<SwapResult> {
         let receipt = self.client.wait_for_transaction(hash).await?;
         if !receipt.receipt.status {
-            return Err(Error::Other(format!("swap transaction {hash:#x} reverted")));
+            return Err(Error::TransactionReverted {
+                hash,
+                receipt: Box::new(receipt),
+            });
         }
 
         let swapped_topic = abi::event_topic(abi::SWAPPED_EVENT);
@@ -477,12 +480,11 @@ impl PropAmmRouter {
             }
         }
 
-        let (amount_in, amount_out, recipient, market_maker) = swapped.ok_or_else(|| {
-            Error::Other(format!(
-                "transaction {hash:#x} emitted no Swapped event from {:#x}",
-                self.address
-            ))
-        })?;
+        let (amount_in, amount_out, recipient, market_maker) =
+            swapped.ok_or(Error::MissingEvent {
+                hash,
+                event: "Swapped",
+            })?;
 
         Ok(SwapResult {
             hash,

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -636,7 +636,7 @@ impl PropAmmRouter {
             QuoteOverrides::Skip => return Ok(CallOverrides::default()),
             QuoteOverrides::Attached => self.overrides.get_overrides().await?,
             QuoteOverrides::Source(source) => source.get_overrides().await?,
-            QuoteOverrides::Snapshot(snapshot) => snapshot.clone(),
+            QuoteOverrides::Snapshot(snapshot) => Arc::new(snapshot.clone()),
         };
 
         let state = to_state_override(

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -634,15 +634,26 @@ impl PropAmmRouter {
     /// overrides — venues revert when the simulated block context doesn't
     /// match their pushed state.
     async fn resolve_overrides(&self, opts: &QuoteOptions) -> Result<CallOverrides> {
-        let snapshot = match &opts.overrides {
+        // Source-backed arms own an Arc (a cheap pointer clone); the
+        // caller-supplied snapshot is borrowed in place. `owned` keeps the Arc
+        // alive so both resolve to a single `&OverridesSnapshot`, with no deep
+        // copy of the caller's snapshot.
+        let owned;
+        let snapshot: &OverridesSnapshot = match &opts.overrides {
             QuoteOverrides::Skip => return Ok(CallOverrides::default()),
-            QuoteOverrides::Attached => self.overrides.get_overrides().await?,
-            QuoteOverrides::Source(source) => source.get_overrides().await?,
-            QuoteOverrides::Snapshot(snapshot) => Arc::new(snapshot.clone()),
+            QuoteOverrides::Attached => {
+                owned = self.overrides.get_overrides().await?;
+                &owned
+            }
+            QuoteOverrides::Source(source) => {
+                owned = source.get_overrides().await?;
+                &owned
+            }
+            QuoteOverrides::Snapshot(snapshot) => snapshot,
         };
 
         let state = to_state_override(
-            &snapshot,
+            snapshot,
             &ToStateOverrideOptions {
                 pamms: None,
                 skip_bebop_default: opts.skip_bebop_default,


### PR DESCRIPTION
This PR contains four independent fixes, one per commit so each can be reviewed in isolation. No public behavior changes beyond the bug fix and the new error variants.

####  1. Correctness bug — fix(sdk): null JSON-RPC error treated as success

  The overrides RPC source rejected any response that included "error": null (a common JSON-RPC shape, e.g. `{"result": {...}, "error": null}`), because Rust's body.get("error") returns Some(Value::Null) for a present-but-null field. That failed every quote against such a server. Now it filters out null so only a real error object fails.

#### 2. Performance — perf(sdk): hand out snapshots behind an Arc

  This is the headline change for the SDK's latency-sensitive goal. Every quote was deep-cloning the nested per-pAMM state maps (HashMap<Address, HashMap<Address, HashMap<H256, U256>>>) while holding the shared mutex, serializing all quoters against the WebSocket frame-merge lock. The trait now returns
  Arc<OverridesSnapshot>, so the hot path is a refcount bump and the lock releases immediately; frame ingestion mutates copy-on-write via Arc::make_mut. The WS warm path also drops from three lock acquisitions to one. Reviewer focus: the trait signature change, Arc::make_mut in handle_frame, and the single-lock get_overrides.

#### 3. Error ergonomics — feat(sdk): typed swap-failure errors

  `wait_for_swap` previously collapsed two distinct outcomes into `Error::Other(String)`, forcing callers to string-match. Now: Error::TransactionReverted { hash, receipt } (carries the boxed receipt so a bot can
  inspect status/gas/logs without another RPC call) and Error::MissingEvent { hash, event }. Reviewer focus / key decision: swap pre-simulation was deliberately not added — propAMM venues only fill against Titan builder-injected liquidity, so an overrides-less eth_call (what the TS reference does) would falsely revert with `InsufficientOutput` on exactly the swaps this router exists for. We chose typed errors over a pre-simulation that risks rejecting valid swaps.

#### 4. Test coverage — test(sdk): 23 offline unit tests

  The crate previously had only ABI selector/parity tests. This adds coverage for the pure, porting-bug-prone logic: slippage rounding/overflow/bounds, parse_units/format_units round-trips, overrides parsing, the Bebop default-slot zeroing invariant, narrow-width uint24/uint16 decode, decode_error naming, and the `Swapped` event data layout wait_for_swap depends on.