### PR TITLE
chore(sdk): rename TS package to 'propamm'

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -15,12 +15,12 @@ pnpm typecheck
 Quote and swap 1 ETH for USDC through the best venue:
 
 ```ts
-import { ContractClient } from "@propamm/sdk/client";
-import { PropAmmRouter } from "@propamm/sdk/router";
-import { ETH_SENTINEL, USDC } from "@propamm/sdk/common/tokens";
-import { applySlippage, deadlineIn, formatUnits, parseEther } from "@propamm/sdk/common/helpers";
-import { mainnet } from "@propamm/sdk/common/chains";
-import { privateKeyToAccount } from "@propamm/sdk/common/accounts";
+import { ContractClient } from "propamm/client";
+import { PropAmmRouter } from "propamm/router";
+import { ETH_SENTINEL, USDC } from "propamm/common/tokens";
+import { applySlippage, deadlineIn, formatUnits, parseEther } from "propamm/common/helpers";
+import { mainnet } from "propamm/common/chains";
+import { privateKeyToAccount } from "propamm/common/accounts";
 
 const account = privateKeyToAccount("0x...");
 const client = new ContractClient({ rpcUrl: "https://...", chain: mainnet, account });
@@ -55,13 +55,13 @@ mainnet router deployment; override with `RPC_URL` / `PRIVATE_KEY` /
 ## Usage
 
 ```ts
-import { ContractClient } from "@propamm/sdk/client";
-import { PropAmmRouter } from "@propamm/sdk/router";
-import { ETH_SENTINEL, USDC, WETH } from "@propamm/sdk/common/tokens";
-import { PAMMS } from "@propamm/sdk/common/pamms";
-import { applySlippage, deadlineIn, parseEther, parseUnits } from "@propamm/sdk/common/helpers";
-import { mainnet } from "@propamm/sdk/common/chains";
-import { privateKeyToAccount } from "@propamm/sdk/common/accounts";
+import { ContractClient } from "propamm/client";
+import { PropAmmRouter } from "propamm/router";
+import { ETH_SENTINEL, USDC, WETH } from "propamm/common/tokens";
+import { PAMMS } from "propamm/common/pamms";
+import { applySlippage, deadlineIn, parseEther, parseUnits } from "propamm/common/helpers";
+import { mainnet } from "propamm/common/chains";
+import { privateKeyToAccount } from "propamm/common/accounts";
 
 const client = new ContractClient({
   rpcUrl: "http://localhost:8545",
@@ -144,7 +144,7 @@ Two sources are available; both need no authentication:
   each quote. No connection to manage.
 
 ```ts
-import { OverridesRpcSource, OverridesWsSource } from "@propamm/sdk/overrides";
+import { OverridesRpcSource, OverridesWsSource } from "propamm/overrides";
 
 // default: streaming WS source created automatically
 const router = new PropAmmRouter(client, ROUTER);
@@ -164,7 +164,7 @@ methods, but they are in the exported ABI — call them through the generic
 client:
 
 ```ts
-import { propAmmRouterAbi } from "@propamm/sdk/router/abi";
+import { propAmmRouterAbi } from "propamm/router/abi";
 
 await client.write({
   address: router.address,
@@ -176,7 +176,7 @@ await client.write({
 
 ## Layout
 
-Source modules map 1:1 to import paths (`src/<path>.ts` → `@propamm/sdk/<path>`):
+Source modules map 1:1 to import paths (`src/<path>.ts` → `propamm/<path>`):
 
 - `src/client.ts` — generic viem-based contract client (`read`/`call`/`write`/`waitForTransaction`); `call` accepts state and block overrides.
 - `src/router/index.ts` — `PropAmmRouter` bindings (`quote`, `swap`, `swapAndWait`, `waitForSwap`, `approve`/`allowance`, views) plus `MAX_FEE_BPS`.

--- a/sdk/typescript/examples/getting-started.ts
+++ b/sdk/typescript/examples/getting-started.ts
@@ -15,19 +15,19 @@
  * swap reverts with `InsufficientOutput` there, raise SLIPPAGE_BPS (live
  * chains fill at the quoted state normally).
  */
-import { ContractClient } from "@propamm/sdk/client";
-import { PropAmmRouter } from "@propamm/sdk/router";
-import { ETH_SENTINEL, USDC } from "@propamm/sdk/common/tokens";
+import { ContractClient } from "propamm/client";
+import { PropAmmRouter } from "propamm/router";
+import { ETH_SENTINEL, USDC } from "propamm/common/tokens";
 import {
   applySlippage,
   deadlineIn,
   formatEther,
   formatUnits,
   parseEther,
-} from "@propamm/sdk/common/helpers";
-import { anvil } from "@propamm/sdk/common/chains";
-import { privateKeyToAccount } from "@propamm/sdk/common/accounts";
-import type { Address, Hash } from "@propamm/sdk";
+} from "propamm/common/helpers";
+import { anvil } from "propamm/common/chains";
+import { privateKeyToAccount } from "propamm/common/accounts";
+import type { Address, Hash } from "propamm";
 
 const RPC_URL = process.env.RPC_URL ?? "http://localhost:8545";
 // anvil's default funded account #0

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@propamm/sdk",
+  "name": "propamm",
   "version": "0.1.0",
   "packageManager": "pnpm@9.15.4",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -26,7 +26,7 @@ import { getContractError } from "viem/utils";
 export interface ContractClientOptions {
   /** JSON-RPC endpoint, e.g. `http://localhost:8545`. */
   rpcUrl: string;
-  /** Target chain (e.g. `mainnet` or `anvil` from `@propamm/sdk/common/chains`). */
+  /** Target chain (e.g. `mainnet` or `anvil` from `propamm/common/chains`). */
   chain: Chain;
   /** Account used to sign transactions. Omit for a read-only client. */
   account?: Account;

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,5 +1,5 @@
 // Slim root: the two entry classes and core types. Everything else lives in
-// subpath modules — see @propamm/sdk/router, @propamm/sdk/common/*.
+// subpath modules — see propamm/router, propamm/common/*.
 export { ContractClient } from "./client.js";
 export type { ContractClientOptions, ReadParams, WriteParams } from "./client.js";
 


### PR DESCRIPTION
Remove the `@propamm/sdk` thought for organizations and flat to just `propamm`