### PR TITLE
chore(sdk): bump SDK version to 1.1.0

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "propamm"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python SDK for interacting with the PropAMM contracts"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "propamm"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "propamm"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "ethrex-common",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propamm"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Rust SDK for the PropAMM Router contract: typed calls, eth_call overrides, and ABI codec over JSON-RPC"
 license = "MIT"

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propamm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "packageManager": "pnpm@11.8.0",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",
   "license": "MIT",


### PR DESCRIPTION
This version adds support for [Titan's price levels](https://docs.titanbuilder.xyz/propamms/takers#pamm-price-level)