### PR TITLE
docs(sdk): update docs

### DIFF
--- a/sdk/docs/src/pages/typescript/getting-started.md
+++ b/sdk/docs/src/pages/typescript/getting-started.md
@@ -14,7 +14,7 @@ import { mainnet } from "propamm/common/chains";
 import { privateKeyToAccount } from "propamm/common/accounts";
 
 const account = privateKeyToAccount("0x...");
-const client = new ContractClient({
+const client = ContractClient.fromRpc({
   rpcUrl: "https://...",
   chain: mainnet,
   account, // omit for a read-only client (quotes and views still work)
@@ -42,3 +42,28 @@ address to target a testnet or local-fork deployment.
 The quote already reflects fresh off-chain liquidity — pAMM state overrides
 are applied automatically. Native ETH input is signalled with `ETH_SENTINEL`
 (no ERC-20 approval needed; `msg.value` is attached automatically).
+
+## Browser wallets
+
+`ContractClient.fromRpc` builds its own viem clients from an RPC URL. In a
+browser app the clients instead come from the connected wallet, so build the
+client with `ContractClient.fromClients` and pass the wallet's own clients —
+e.g. wagmi's `usePublicClient` / `useWalletClient`. Writes are then signed by
+the wallet (MetaMask, WalletConnect, ...) over its own transport.
+
+```ts
+import { ContractClient } from "propamm/client";
+import { usePublicClient, useWalletClient } from "wagmi";
+
+// viem public client for reads and quote simulations
+const publicClient = usePublicClient();
+
+// viem wallet client for writes, signing through the connected wallet (MetaMask)
+const { data: walletClient } = useWalletClient();
+
+// SDK client backed by the wallet's viem clients
+const client = ContractClient.fromClients({ publicClient, walletClient });
+```
+
+`walletClient` is `undefined` until a wallet connects; omit it (pass only
+`publicClient`) for a read-only client that can still quote and read views.

--- a/sdk/docs/src/pages/typescript/router/quote.md
+++ b/sdk/docs/src/pages/typescript/router/quote.md
@@ -32,7 +32,7 @@ import { ContractClient } from "propamm/client";
 import { PropAmmRouter } from "propamm/router";
 import { mainnet } from "propamm/common/chains";
 
-export const client = new ContractClient({
+export const client = ContractClient.fromRpc({
   rpcUrl: "https://...",
   chain: mainnet,
 });

--- a/sdk/docs/src/pages/typescript/router/swap.md
+++ b/sdk/docs/src/pages/typescript/router/swap.md
@@ -36,7 +36,7 @@ import { mainnet } from "propamm/common/chains";
 import { privateKeyToAccount } from "propamm/common/accounts";
 
 export const account = privateKeyToAccount("0x...");
-export const client = new ContractClient({
+export const client = ContractClient.fromRpc({
   rpcUrl: "https://...",
   chain: mainnet,
   account,


### PR DESCRIPTION
This PR updates the Typescript SDK documentation with the changes introduced in the PR #56.
The main changes were:
- The default constructor for `ContractClient` is now private
- There are two new static constructors: `fromRpc` and `fromClients` (the latter one allows signing swap transactions via browser wallets).

The docs can built and served in the browser with the following commands

```bash
cd sdk/docs
pnpm install --ignore-workspace
./node_modules/.bin/vitepress dev
```