### PR TITLE
chore(sdk): bump Typescript SDK version to 1.2.0

### DIFF
--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propamm",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "packageManager": "pnpm@11.8.0",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",
   "license": "MIT",


### PR DESCRIPTION
This PR bumps the Typescript SDK version to 1.2.0