### PR TITLE
fix(sdk): compute state overrides timestamp from slot

### DIFF
--- a/sdk/typescript/src/overrides/index.ts
+++ b/sdk/typescript/src/overrides/index.ts
@@ -31,11 +31,22 @@ export type ContractDiffs = Record<Address, SlotDiffs>;
 export interface OverridesSnapshot {
   /** Block the overrides were generated against. */
   blockNumber?: bigint;
+  /** Beacon-chain slot the overrides were generated against. */
+  slot?: bigint;
   /** Generation time in nanoseconds since epoch. */
   timestampNs?: bigint;
   /** pAMM address → contract address → slot diffs. */
   perPamm: Record<Address, ContractDiffs>;
 }
+
+/**
+ * Mainnet beacon-chain genesis time and slot length. The canonical timestamp
+ * of a block is `genesis + slot*12`; venues check `block.timestamp` against the
+ * state they pushed, so quote sims must pin this slot-derived time (not the
+ * frame's emit time). Matches Titan's reference `quoter.py`.
+ */
+export const BEACON_GENESIS_TS = 1_606_824_023n;
+export const SECS_PER_SLOT = 12n;
 
 /** Anything quotes can pull override snapshots from. */
 export interface OverridesSource {
@@ -81,6 +92,7 @@ export function parseOverridesMessage(raw: unknown): OverridesSnapshot {
 
   return {
     blockNumber: parseBlockNumber(message["blockNumber"] ?? message["block_number"]),
+    slot: parseBlockNumber(message["slot"]),
     timestampNs:
       typeof message["timestamp"] === "number" ? BigInt(message["timestamp"]) : undefined,
     perPamm,
@@ -239,6 +251,7 @@ export class OverridesWsSource extends WsSource<OverridesSnapshot> implements Ov
     const frame = parseOverridesMessage(JSON.parse(data));
     Object.assign(this.snapshot.perPamm, frame.perPamm);
     if (frame.blockNumber !== undefined) this.snapshot.blockNumber = frame.blockNumber;
+    if (frame.slot !== undefined) this.snapshot.slot = frame.slot;
     if (frame.timestampNs !== undefined) this.snapshot.timestampNs = frame.timestampNs;
   }
 

--- a/sdk/typescript/src/router/index.ts
+++ b/sdk/typescript/src/router/index.ts
@@ -17,7 +17,9 @@ import {
 import { propAmmRouterAbi } from "./abi.js";
 import { ETH_SENTINEL } from "../common/tokens.js";
 import {
+  BEACON_GENESIS_TS,
   OverridesWsSource,
+  SECS_PER_SLOT,
   toStateOverride,
   type OverridesSnapshot,
   type OverridesSource,
@@ -352,9 +354,11 @@ export class PropAmmRouter {
    * per-call source/snapshot (or the router's attached source), then flatten
    * the snapshot into viem's state-override format. The snapshot's block
    * number and timestamp are attached only alongside overrides — venues
-   * revert when the simulated block context doesn't match their pushed state
-   * (the timestamp matters on forks, whose `block.timestamp` lags the
-   * snapshot's freshness window).
+   * revert when the simulated block context doesn't match their pushed state.
+   * The timestamp is the slot's canonical block time (`genesis + slot*12`),
+   * falling back to the emit time when no slot is present; venues validate
+   * `block.timestamp` against the state they pushed, which is keyed to the slot,
+   * not to the frame's emit time.
    */
   private async resolveOverrides(
     opts?: QuoteOptions,
@@ -371,10 +375,20 @@ export class PropAmmRouter {
     return {
       stateOverride,
       blockNumber: snapshot.blockNumber,
-      blockTimestamp:
-        snapshot.timestampNs !== undefined ? snapshot.timestampNs / 1_000_000_000n : undefined,
+      blockTimestamp: blockTimeSecs(snapshot),
     };
   }
+}
+
+/**
+ * Canonical block time (seconds) for a snapshot: derived from the beacon slot
+ * (`genesis + slot*12`), falling back to the emit timestamp when no slot is
+ * present, or `undefined` when neither is known.
+ */
+function blockTimeSecs(snapshot: OverridesSnapshot): bigint | undefined {
+  if (snapshot.slot !== undefined) return BEACON_GENESIS_TS + snapshot.slot * SECS_PER_SLOT;
+  if (snapshot.timestampNs !== undefined) return snapshot.timestampNs / 1_000_000_000n;
+  return undefined;
 }
 
 /** Quote selector per venue-restriction mode. */


### PR DESCRIPTION
This PR updates the Typescript SDK so that the state overrides in `quote` calls compute the `time` field from the Titan's stream `slot` field instead of deriving it from Titan's stream `timestamp` field.

### How to test

To test the fix, we use the `price-feed.ts` script, which calls `quoteV1` for different USDC amounts, prints the best quote and the venue that offered it.

If the script logs show that uniswap is the best venue, then it means the state overrides included in the quote are not working (i.e. the `time` field is wrong, which causes the Fermi and Kipseli `quote`to revert, leaving Uniswap as the "best available venue")

Run the `price-feed.ts` script in the `main` branch first:

```bash
git checkout main
cd sdk/typescript
npm run build
RPC_URL=https://ethereum-rpc.publicnode.com node examples/price-feed.ts
```

In this case, the logs should be similar to the following (i.e. uniswap offers the best quote almost always. That means that the state overrides are not working).

```
100 USDC -> 0.06385150787759283 ETH @ 1566.13 USDC/ETH via uniswap
1000 USDC -> 0.6385089939619324 ETH @ 1566.15 USDC/ETH via uniswap
10000 USDC -> 6.384481525399702 ETH @ 1566.30 USDC/ETH via uniswap
```

Now run the same example but in the current branch

```bash
git checkout sdk/ts/fix-quoting-state-overrides
npm run build
RPC_URL=https://ethereum-rpc.publicnode.com node examples/price-feed.ts
```

This time the logs should consistently show a venue different than uniswap, which means the state overrides are now working.