### PR TITLE
fix(sdk): update Rust SDK to compute `time` override from `slot`

### DIFF
--- a/sdk/rust/src/overrides/mod.rs
+++ b/sdk/rust/src/overrides/mod.rs
@@ -40,6 +40,13 @@ pub const BEBOP_DEFAULT_SLOT: H256 = H256(hex!(
     "3ca381a3d43d4e593578057c4abe441ad9df02f080defd17d2b6e6190cdcd936"
 ));
 
+/// Mainnet beacon-chain genesis time and slot length. The canonical timestamp
+/// of a block is `genesis + slot*12`; venues check `block.timestamp` against the
+/// state they pushed, so quote sims must pin this slot-derived time (not the
+/// frame's emit time). Matches Titan's reference `quoter.py`.
+pub const BEACON_GENESIS_TS: u64 = 1_606_824_023;
+pub const SECS_PER_SLOT: u64 = 12;
+
 /// Storage slot diffs for one contract: slot → value.
 pub type SlotDiffs = HashMap<H256, U256>;
 /// Per-contract slot diffs: contract address → slots.
@@ -50,10 +57,24 @@ pub type ContractDiffs = HashMap<Address, SlotDiffs>;
 pub struct OverridesSnapshot {
     /// Block the overrides were generated against.
     pub block_number: Option<u64>,
+    /// Beacon-chain slot the overrides were generated against.
+    pub slot: Option<u64>,
     /// Generation time in nanoseconds since epoch.
     pub timestamp_ns: Option<u64>,
     /// pAMM address → contract address → slot diffs.
     pub per_pamm: HashMap<Address, ContractDiffs>,
+}
+
+impl OverridesSnapshot {
+    /// Canonical block time (seconds) from the beacon slot; emit timestamp as
+    /// fallback. Venues validate `block.timestamp` against the state they
+    /// pushed, which is keyed to the slot, not to the frame's emit time.
+    pub fn block_time_secs(&self) -> Option<u64> {
+        match self.slot {
+            Some(slot) => Some(BEACON_GENESIS_TS + slot * SECS_PER_SLOT),
+            None => self.timestamp_ns.map(|ns| ns / 1_000_000_000),
+        }
+    }
 }
 
 /// Anything quotes can pull override snapshots from.
@@ -95,6 +116,7 @@ pub fn parse_overrides_message(raw: &Value) -> Result<OverridesSnapshot> {
             .get("blockNumber")
             .or_else(|| object.get("block_number"))
             .and_then(parse_block_number),
+        slot: object.get("slot").and_then(parse_block_number),
         timestamp_ns: object.get("timestamp").and_then(Value::as_u64),
         per_pamm,
     })
@@ -309,6 +331,9 @@ impl WsHandler for OverridesWsHandler {
         if frame.block_number.is_some() {
             s.block_number = frame.block_number;
         }
+        if frame.slot.is_some() {
+            s.slot = frame.slot;
+        }
         if frame.timestamp_ns.is_some() {
             s.timestamp_ns = frame.timestamp_ns;
         }
@@ -424,6 +449,7 @@ mod tests {
         per_pamm.insert(pamm, contracts);
         OverridesSnapshot {
             block_number,
+            slot: None,
             timestamp_ns: None,
             per_pamm,
         }
@@ -453,7 +479,7 @@ mod tests {
             r#"{{
                 "blockNumber": 24285034,
                 "timestamp": 1700000000000000000,
-                "slot": "meta-key-ignored",
+                "slot": 11833333,
                 "{pamm}": {{ "stateOverride": {{
                     "{contract}": {{ "stateDiff": {{ "0x1": "0x2a" }} }}
                 }} }}
@@ -463,6 +489,9 @@ mod tests {
         let snapshot = parse_overrides_message(&message).unwrap();
 
         assert_eq!(snapshot.block_number, Some(24_285_034));
+        assert_eq!(snapshot.slot, Some(11_833_333));
+        // Canonical block time is genesis + slot*12, not the emit timestamp.
+        assert_eq!(snapshot.block_time_secs(), Some(1_748_824_019));
         assert_eq!(snapshot.timestamp_ns, Some(1_700_000_000_000_000_000));
         assert_eq!(snapshot.per_pamm.len(), 1);
         let pamm = parse_address(pamm).unwrap();

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -504,7 +504,8 @@ impl PropAmmRouter {
             state: Some(state),
             block: Some(BlockOverrideSet {
                 number: snapshot.block_number,
-                time: snapshot.timestamp_ns.map(|ns| ns / 1_000_000_000),
+                // Canonical slot time (genesis + slot*12); emit time as fallback.
+                time: snapshot.block_time_secs(),
                 ..Default::default()
             }),
         })


### PR DESCRIPTION
This PR updates the Rust SDK so that state overrides compute the `time` field from the Titan's stream `slot` instead of deriving it from Titan's `timestamp`.

### How to test it

To test the fix, we use a script that calls `quote` with different USDC amounts, and for each amount it shows the best quote and the venue that offers it.
From the repository root directory, run the following command to write the script to `examples/price_feed.rs`.

```bash
cat > sdk/rust/examples/price_feed.rs << 'EOF'
use std::time::Duration;
use propamm::common::helpers::{format_ether, format_units, parse_address, parse_units};
use propamm::common::tokens::{ETH_SENTINEL, USDC};
use propamm::{ContractClient, PropAmmRouter};

const USDC_DECIMALS: u32 = 6;

#[tokio::main(flavor = "current_thread")]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| "http://localhost:8545".into());
    let router_address = parse_address(
        &std::env::var("ROUTER_ADDRESS")
            .unwrap_or_else(|_| "0x4DdF368080CD7946db5b459aD591c350158175e1".into()),
    )?;

    let client = ContractClient::connect(&rpc_url)?;
    let router = PropAmmRouter::new(client, router_address);

    loop {
        for amount in ["10", "100", "1000"] {
            let amount_in = parse_units(amount, USDC_DECIMALS)?;
            let quote = router.quote(USDC, ETH_SENTINEL, amount_in).await?;
            println!(
                "quote: {} USDC -> {} ETH via {:#x}",
                format_units(amount_in, USDC_DECIMALS),
                format_ether(quote.amount_out),
                quote.venue
            );
        }
        tokio::time::sleep(Duration::from_secs(2)).await;
    }
}
EOF
```

Then, run the script from the `main` branch. In this case the script should log that uniswap (`0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45`) offers the best quote. This means the state overrides are not working (i.e. the `time` field is wrong)

```bash
git checkout main
cd sdk/rust
RPC_URL=https://ethereum-rpc.publicnode.com cargo run --example price_feed
```

Next, checkout to the current branch and run the script from it. Now, the script should log that the best quote is offered by a PropAMM (not uniswap). That means the `time` field in the state override is right.

```bash
git checkout sdk/rust/fix-quoting-state-overrides
RPC_URL=https://ethereum-rpc.publicnode.com cargo run --example price_feed
```



