### PR TITLE
fix(sdk): update python SDK to compute time override from slot

### DIFF
--- a/sdk/python/src/propamm/overrides/__init__.py
+++ b/sdk/python/src/propamm/overrides/__init__.py
@@ -41,6 +41,13 @@ DEFAULT_OVERRIDES_WS_URL = "wss://rpc.titanbuilder.xyz/ws/pamm_quote_stream"
 #: on-chain Bebop price cannot win a best-quote selection it could never fill.
 BEBOP_DEFAULT_SLOT = "0x3ca381a3d43d4e593578057c4abe441ad9df02f080defd17d2b6e6190cdcd936"
 
+#: Mainnet beacon-chain genesis time and slot length. The canonical timestamp of
+#: a block is ``genesis + slot * 12``; venues check ``block.timestamp`` against
+#: the state they pushed, so quote sims must pin this slot-derived time (not the
+#: frame's emit time). Matches Titan's reference ``quoter.py``.
+BEACON_GENESIS_TS = 1_606_824_023
+SECS_PER_SLOT = 12
+
 _BEBOP_LOWER = BEBOP.lower()
 # Deprecated Bebop deployment still whitelisted on the router; it receives no
 # fresh overrides, so its stale on-chain price is always neutralized (see
@@ -61,6 +68,8 @@ class OverridesSnapshot:
 
     #: Block the overrides were generated against.
     block_number: int | None = None
+    #: Beacon-chain slot the overrides were generated against.
+    slot: int | None = None
     #: Generation time in nanoseconds since epoch.
     timestamp_ns: int | None = None
     #: pAMM address (lowercased) -> contract address (lowercased) -> slot diffs.
@@ -70,6 +79,7 @@ class OverridesSnapshot:
         """A deep-ish copy so a later frame can't mutate a handed-out snapshot."""
         return OverridesSnapshot(
             block_number=self.block_number,
+            slot=self.slot,
             timestamp_ns=self.timestamp_ns,
             per_pamm={
                 pamm: {contract: dict(slots) for contract, slots in contracts.items()}
@@ -148,6 +158,7 @@ def parse_overrides_message(raw: Any) -> OverridesSnapshot:
 
     return OverridesSnapshot(
         block_number=_parse_block_number(raw.get("blockNumber", raw.get("block_number"))),
+        slot=_parse_block_number(raw.get("slot")),
         timestamp_ns=raw["timestamp"] if isinstance(raw.get("timestamp"), int) else None,
         per_pamm=per_pamm,
     )
@@ -370,6 +381,8 @@ class OverridesWsSource(OverridesSource):
         self._snapshot.per_pamm.update(copy.deepcopy(frame.per_pamm))
         if frame.block_number is not None:
             self._snapshot.block_number = frame.block_number
+        if frame.slot is not None:
+            self._snapshot.slot = frame.slot
         if frame.timestamp_ns is not None:
             self._snapshot.timestamp_ns = frame.timestamp_ns
         self._has_frame = True

--- a/sdk/python/src/propamm/router/bindings.py
+++ b/sdk/python/src/propamm/router/bindings.py
@@ -21,6 +21,8 @@ from ..common.helpers import parse_address
 from ..common.tokens import ETH_SENTINEL
 from ..error import InvalidInputError, MissingEventError, RevertError, TransactionRevertedError
 from ..overrides import (
+    BEACON_GENESIS_TS,
+    SECS_PER_SLOT,
     OverridesSnapshot,
     OverridesSource,
     OverridesWsSource,
@@ -329,7 +331,10 @@ class PropAmmRouter:
         Returns ``None`` when no overrides apply (the quote runs via web3's
         plain ``.call()``). The snapshot's block number and timestamp are
         attached only alongside overrides — venues revert when the simulated
-        block context doesn't match their pushed state.
+        block context doesn't match their pushed state. The timestamp is the
+        slot's canonical block time (``genesis + slot*12``), falling back to the
+        emit time when no slot is present; venues validate ``block.timestamp``
+        against the state they pushed, which is keyed to the slot.
         """
         chosen = opts.overrides
         if chosen is None:
@@ -350,9 +355,19 @@ class PropAmmRouter:
             return None
 
         overrides: dict[str, Any] = {"state_override": state, "block_number": snapshot.block_number}
-        if snapshot.timestamp_ns is not None:
-            overrides["block_timestamp"] = snapshot.timestamp_ns // 1_000_000_000
+        block_timestamp = _block_time_secs(snapshot)
+        if block_timestamp is not None:
+            overrides["block_timestamp"] = block_timestamp
         return overrides
+
+
+def _block_time_secs(snapshot: OverridesSnapshot) -> int | None:
+    """Canonical block time (seconds) from the beacon slot; emit time as fallback."""
+    if snapshot.slot is not None:
+        return BEACON_GENESIS_TS + snapshot.slot * SECS_PER_SLOT
+    if snapshot.timestamp_ns is not None:
+        return snapshot.timestamp_ns // 1_000_000_000
+    return None
 
 
 def _venue_dispatch(venues: list[str] | None) -> tuple[str, list]:


### PR DESCRIPTION
This PR updates the Python SDK so that state overrides compute the `time` field from the Titan's stream `slot` instead of deriving it from Titan's `timestamp`.

### How to test it

To test the fix, we use a script that calls `quote` with different USDC amounts, and for each amount it shows the best quote and the venue that offers it.
From the repository root directory, run the following command to save the `price_feed.py` script.

```bash
cat > sdk/python/examples/price_feed.py << 'EOF'
from __future__ import annotations
import asyncio
import os
from propamm import ContractClient, PropAmmRouter
from propamm.common.helpers import (format_ether,format_units,parse_units)
from propamm.common.tokens import ETH_SENTINEL, USDC
import time

USDC_DECIMALS = 6
RPC_URL = os.getenv("RPC_URL", "http://localhost:8545")
ROUTER_ADDRESS = os.getenv("ROUTER_ADDRESS", "0x4DdF368080CD7946db5b459aD591c350158175e1")

async def main() -> None:
    client = ContractClient(RPC_URL)
    router = PropAmmRouter(client, ROUTER_ADDRESS)
    while True:
        for amount in ["10", "100", "1000"]:
            amount_in = parse_units(amount, USDC_DECIMALS)
            quote = await router.quote(USDC, ETH_SENTINEL, amount_in)
            print(
                f"quote: {format_units(amount_in, USDC_DECIMALS)} USDC -> "
                f"{format_ether(quote.amount_out)} ETH via {quote.venue}"
            )
        print("\n")
        time.sleep(2)

if __name__ == "__main__":
    asyncio.run(main())

EOF
```

Then, run the script from the `main` branch. In this case the script should log that uniswap (`0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45`) offers the best quote. This means the state overrides are not working (i.e. the `time` field is wrong)

```bash
git checkout main
cd sdk/python
RPC_URL=https://ethereum-rpc.publicnode.com python3 examples/price_feed.py
```

Next, checkout to the current branch and run the script from it. Now, the script should log that the best quote is offered by a PropAMM (not uniswap). That means the `time` field in the state override is right.

```bash
git checkout sdk/python/fix-quoting-state-overrides
RPC_URL=https://ethereum-rpc.publicnode.com python3 examples/price_feed.py
```
