### PR TITLE
chore(sdk): bump SDK versions

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Python SDK (`propamm`) are documented here.
 
+## [1.1.2] - 2026-06-25
+
+### Fixed
+
+- State-override quotes now pin the simulated `block.timestamp` to the beacon
+  slot's canonical block time (`genesis + slot*12`) instead of the frame's emit
+  time, falling back to the emit time when no slot is present. Venues validate
+  `block.timestamp` against the state they pushed, which is keyed to the slot.
+  ([#63](https://github.com/lambdaclass/propamm-router-contracts/pull/63))
+
 ## [1.1.1] - 2026-06-24
 
 ### Added

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "propamm"
-version = "1.1.0"
+version = "1.1.2"
 description = "Python SDK for interacting with the PropAMM contracts"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "propamm"
-version = "1.1.0"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Rust SDK (`propamm`) are documented here.
 
+## [1.1.1] - 2026-06-25
+
+### Fixed
+
+- State-override quotes now pin the simulated `block.timestamp` to the beacon
+  slot's canonical block time (`genesis + slot*12`) instead of the frame's emit
+  time, falling back to the emit time when no slot is present. Venues validate
+  `block.timestamp` against the state they pushed, which is keyed to the slot.
+  ([#62](https://github.com/lambdaclass/propamm-router-contracts/pull/62))
+
 ## [1.1.0] - 2026-06-24
 
 ### Added

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "propamm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "ethrex-common",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propamm"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 description = "Rust SDK for the PropAMM Router contract: typed calls, eth_call overrides, and ABI codec over JSON-RPC"
 license = "MIT"

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
+## [1.2.1] - 2026-06-25
+
+### Fixed
+
+- State-override quotes now pin the simulated `block.timestamp` to the beacon
+  slot's canonical block time (`genesis + slot*12`) instead of the frame's emit
+  time, falling back to the emit time when no slot is present. Venues validate
+  `block.timestamp` against the state they pushed, which is keyed to the slot.
+  ([#61](https://github.com/lambdaclass/propamm-router-contracts/pull/61))
+
 ## [1.2.0] - 2026-06-25
 
 ### Added

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propamm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packageManager": "pnpm@11.8.0",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",
   "license": "MIT",


### PR DESCRIPTION
Bump SDKs to include the timestamp/slot fix