### PR TITLE
ci(sdk): trigger docs deploy on changelog files change

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - "sdk/docs/**"
+      - "sdk/python/CHANGELOG.md"
+      - "sdk/rust/CHANGELOG.md"
+      - "sdk/typescript/CHANGELOG.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changelog files for the SDKs are on each language dir, and included in the documentation. Adding it to the trigger path in the docs deployment CI so changes to the changelogs re-deploy the docs website