### PR TITLE
perf(contracts): remove extra hop transfer

### DIFF
--- a/sdk/python/src/propamm/router/propamm_router_abi.json
+++ b/sdk/python/src/propamm/router/propamm_router_abi.json
@@ -51,6 +51,11 @@
         "internalType": "uint256"
       },
       {
+        "name": "payer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
         "name": "recipient",
         "type": "address",
         "internalType": "address"

--- a/sdk/rust/src/router/abi.rs
+++ b/sdk/rust/src/router/abi.rs
@@ -368,7 +368,7 @@ mod tests {
     /// Functions present in the contract ABI that the SDK deliberately does
     /// not bind: self-call internals, UUPS/AccessManaged plumbing.
     const OMITTED_FUNCTIONS: &[&str] = &[
-        "_dispatchVenue(address,address,address,uint256,uint256,address,uint256,uint256)",
+        "_dispatchVenue(address,address,address,uint256,uint256,address,address,uint256,uint256)",
         "initialize(address,address,address)",
         "proxiableUUID()",
         "upgradeToAndCall(address,bytes)",

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -299,14 +299,15 @@ contract PropAMMRouter is
         require(block.timestamp <= deadline, Expired());
 
         address tokenIn_ = tokenIn;
+        address payer = msg.sender;
         if (tokenIn == ETH_SENTINEL) {
             // If tokenIn is ETH, we wrap it and use WETH as the tokenIn for swap
             require(msg.value == amountIn, InvalidValue(amountIn, msg.value));
             IWETH(WETH).deposit{value: msg.value}();
             tokenIn_ = WETH;
+            payer = address(this);
         } else {
             require(msg.value == 0, InvalidValue(0, msg.value));
-            IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
         }
 
         address tokenOut_ = tokenOut;
@@ -322,7 +323,7 @@ contract PropAMMRouter is
 
         if (venue != fallbackSwapRouter) {
             try this._dispatchVenue(
-                venue, tokenIn_, tokenOut_, amountIn, amountOutMin, recipient_, deadline, prevTokenOutBalance
+                venue, tokenIn_, tokenOut_, amountIn, amountOutMin, payer, recipient_, deadline, prevTokenOutBalance
             ) returns (
                 uint256 amountOut_
             ) {
@@ -336,6 +337,9 @@ contract PropAMMRouter is
             }
         }
 
+        if (tokenIn != ETH_SENTINEL) {
+            IERC20(tokenIn_).safeTransferFrom(msg.sender, address(this), amountIn);
+        }
         UniV3Router.swapExactIn(
             tokenIn_,
             tokenOut_,
@@ -377,6 +381,7 @@ contract PropAMMRouter is
         address tokenOut,
         uint256 amountIn,
         uint256 amountOutMin,
+        address payer,
         address recipient,
         uint256 deadline,
         uint256 prevTokenOutBalance
@@ -391,7 +396,11 @@ contract PropAMMRouter is
         // consume it and deliver `tokenOut` straight to `recipient`. A revert
         // (or an under-delivery caught below) rolls back this transfer via the
         // `_coreSwap` self-call `try/catch` and engages the Uniswap fallback.
-        IERC20(tokenIn).safeTransfer(venue, amountIn);
+        if (payer == address(this)) {
+            IERC20(tokenIn).safeTransfer(venue, amountIn);
+        } else {
+            IERC20(tokenIn).safeTransferFrom(payer, venue, amountIn);
+        }
         IPropAMM(venue).swap(tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
 
         amountOut = IERC20(tokenOut).balanceOf(recipient) - prevTokenOutBalance;

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -337,6 +337,9 @@ contract PropAMMRouter is
             }
         }
 
+        // Uniswap is pull-based, so the router needs to pull the tokens from the sender.
+        // If the input token is ETH, it was already wrapped and the router already
+        // has the WETH.
         if (tokenIn != ETH_SENTINEL) {
             IERC20(tokenIn_).safeTransferFrom(msg.sender, address(this), amountIn);
         }

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -362,7 +362,7 @@ contract PropAMMRouter is
         return (amountOut, fallbackSwapRouter);
     }
 
-    /// @notice Executes a swap on a venue with funds already held by this contract.
+    /// @notice Executes a swap on a venue, sourcing `tokenIn` from `payer`.
     /// @dev Reverts `UnknownVenue` for non-whitelisted addresses, or
     /// bubbles up the underlying propAMM router's revert.
     /// @param venue The venue to route the swap through.
@@ -371,6 +371,8 @@ contract PropAMMRouter is
     /// @param amountIn The exact amount of `tokenIn` to sell.
     /// @param amountOutMin The minimum acceptable amount of `tokenOut`; an
     /// under-fill below this triggers a revert here so the fallback engages.
+    /// @param payer Account `tokenIn` is taken from: the router (`address(this)`)
+    /// commonly for wrapped ETH, otherwise the caller.
     /// @param recipient The address that will receive `tokenOut`.
     /// @param deadline Unix timestamp after which the swap is no longer valid;
     /// @param prevTokenOutBalance `recipient`'s `tokenOut` balance snapshotted

--- a/test/PropAMMRouterEth.t.sol
+++ b/test/PropAMMRouterEth.t.sol
@@ -110,13 +110,7 @@ contract PropAMMRouterEthTest is Test {
         // `deadVenue` has no code, so `_dispatchVenue` reverts (the WETH
         // safeTransfer to it rolls back) and `_coreSwap` engages the fallback.
         (uint256 amountOut, address executedVenue) = router.swapViaVenueV1{value: AMOUNT_IN}(
-            address(deadVenue),
-            ETH_SENTINEL,
-            address(tokenOut),
-            AMOUNT_IN,
-            AMOUNT_IN,
-            recipient,
-            block.timestamp + 1
+            address(deadVenue), ETH_SENTINEL, address(tokenOut), AMOUNT_IN, AMOUNT_IN, recipient, block.timestamp + 1
         );
 
         assertEq(executedVenue, address(fallbackRouter), "should fall back to Uniswap");

--- a/test/PropAMMRouterEth.t.sol
+++ b/test/PropAMMRouterEth.t.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {AccessManager} from "@openzeppelin/contracts/access/manager/AccessManager.sol";
+import {PropAMMRouter} from "../src/PropAMMRouter.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockWETH} from "./mocks/MockWETH.sol";
+import {MockV3SwapRouter} from "./mocks/MockV3SwapRouter.sol";
+import {MockQuoterV2} from "./mocks/MockQuoterV2.sol";
+import {MockPropAMMExactOut} from "./mocks/MockPropAMMExactOut.sol";
+import {ETH_SENTINEL, WETH} from "../src/libraries/Constants.sol";
+import "../src/libraries/Errors.sol";
+
+/// @title PropAMMRouterEthTest
+/// @notice Exercises the native-ETH input paths through `_coreSwap`: ETH is
+/// wrapped to WETH held by the router, so the venue path must `safeTransfer`
+/// the router's WETH (payer == router) and the Uniswap fallback must NOT
+/// re-pull. These six paths regressed repeatedly while moving to the
+/// direct-pull model and an ERC-20-only suite never caught it.
+/// @dev The router hard-codes the mainnet WETH address, so a `MockWETH` is
+/// `vm.etch`ed there to make `IWETH(WETH).deposit` work off-fork.
+contract PropAMMRouterEthTest is Test {
+    PropAMMRouter internal router;
+    AccessManager internal manager;
+    MockV3SwapRouter internal fallbackRouter; // pulls tokenIn, so router ends clean
+    MockQuoterV2 internal quoter;
+    MockPropAMMExactOut internal venue; // 1:1 priced propAMM
+    MockERC20 internal tokenOut;
+
+    address internal owner = address(this);
+    address internal recipient = makeAddr("recipient");
+
+    // Whitelisted but code-less: its `swap` reverts, so `_dispatchVenue` rolls
+    // back and the Uniswap fallback engages — used to drive the venue->fallback
+    // path with an ETH input.
+    address internal deadVenue = address(0xDEAD);
+
+    uint256 internal constant AMOUNT_IN = 1 ether;
+
+    function setUp() public {
+        fallbackRouter = new MockV3SwapRouter();
+        quoter = new MockQuoterV2();
+        tokenOut = new MockERC20("TokenOut", "TOUT");
+
+        // Put a working WETH at the address the router hard-codes.
+        vm.etch(WETH, address(new MockWETH()).code);
+
+        manager = new AccessManager(owner);
+        PropAMMRouter impl = new PropAMMRouter();
+        bytes memory initData =
+            abi.encodeCall(PropAMMRouter.initialize, (address(fallbackRouter), address(quoter), address(manager)));
+        router = PropAMMRouter(payable(address(new ERC1967Proxy(address(impl), initData))));
+
+        // A 1:1 propAMM, funded with tokenOut liquidity to deliver.
+        venue = new MockPropAMMExactOut(1, 1);
+        tokenOut.mint(address(venue), 1_000 ether);
+        router.addVenue(address(venue));
+        router.addVenue(deadVenue);
+
+        // Pre-fund + arm the fallback so it can deliver tokenOut when engaged.
+        tokenOut.mint(address(fallbackRouter), 1_000 ether);
+        fallbackRouter.setAmountOut(AMOUNT_IN);
+        quoter.setQuote(AMOUNT_IN);
+
+        vm.deal(address(this), 100 ether);
+    }
+
+    // --- ETH -> venue (happy path) ----------------------------------------
+
+    function test_ethIn_venue_executes() public {
+        (uint256 amountOut, address executedVenue) = router.swapViaVenueV1{value: AMOUNT_IN}(
+            address(venue), ETH_SENTINEL, address(tokenOut), AMOUNT_IN, AMOUNT_IN, recipient, block.timestamp + 1
+        );
+
+        assertEq(executedVenue, address(venue), "should execute on the venue, not fall back");
+        assertEq(amountOut, AMOUNT_IN, "1:1 venue should deliver amountIn");
+        assertEq(tokenOut.balanceOf(recipient), AMOUNT_IN, "recipient tokenOut");
+        // Router pushed all wrapped WETH to the venue; nothing left behind.
+        assertEq(IERC20(WETH).balanceOf(address(router)), 0, "no WETH stranded in router");
+        assertEq(address(router).balance, 0, "no ETH stranded in router");
+    }
+
+    // --- ETH -> Uniswap fallback (selected directly) ----------------------
+
+    function test_ethIn_fallback_direct() public {
+        (uint256 amountOut, address executedVenue) = router.swapViaVenueV1{value: AMOUNT_IN}(
+            address(fallbackRouter),
+            ETH_SENTINEL,
+            address(tokenOut),
+            AMOUNT_IN,
+            AMOUNT_IN,
+            recipient,
+            block.timestamp + 1
+        );
+
+        assertEq(executedVenue, address(fallbackRouter), "should execute on the fallback");
+        assertEq(amountOut, AMOUNT_IN, "fallback delivered amount");
+        assertEq(tokenOut.balanceOf(recipient), AMOUNT_IN, "recipient tokenOut");
+        // The fallback pulled the wrapped WETH (it transferFroms); router clean.
+        assertEq(IERC20(WETH).balanceOf(address(router)), 0, "no WETH stranded in router");
+        assertEq(address(router).balance, 0, "no ETH stranded in router");
+    }
+
+    // --- ETH -> venue fails -> Uniswap fallback ---------------------------
+
+    function test_ethIn_venueFails_fallsBackToUniswap() public {
+        // `deadVenue` has no code, so `_dispatchVenue` reverts (the WETH
+        // safeTransfer to it rolls back) and `_coreSwap` engages the fallback.
+        (uint256 amountOut, address executedVenue) = router.swapViaVenueV1{value: AMOUNT_IN}(
+            address(deadVenue),
+            ETH_SENTINEL,
+            address(tokenOut),
+            AMOUNT_IN,
+            AMOUNT_IN,
+            recipient,
+            block.timestamp + 1
+        );
+
+        assertEq(executedVenue, address(fallbackRouter), "should fall back to Uniswap");
+        assertEq(amountOut, AMOUNT_IN, "fallback delivered amount");
+        assertEq(tokenOut.balanceOf(recipient), AMOUNT_IN, "recipient tokenOut");
+        assertEq(IERC20(WETH).balanceOf(address(deadVenue)), 0, "rolled-back transfer left nothing at dead venue");
+        assertEq(IERC20(WETH).balanceOf(address(router)), 0, "no WETH stranded in router");
+        assertEq(address(router).balance, 0, "no ETH stranded in router");
+    }
+
+    // --- ETH -> swapV1 auto-selects the venue -----------------------------
+
+    function test_ethIn_swapV1_picksVenue() public {
+        // Venue quotes 1:1 (AMOUNT_IN); make the fallback quote worse so the
+        // venue is chosen, proving the pick-best path also wraps ETH correctly.
+        quoter.setQuote(AMOUNT_IN / 2);
+
+        (uint256 amountOut, address executedVenue) = router.swapV1{value: AMOUNT_IN}(
+            ETH_SENTINEL, address(tokenOut), AMOUNT_IN, AMOUNT_IN, recipient, block.timestamp + 1
+        );
+
+        assertEq(executedVenue, address(venue), "best quote is the venue");
+        assertEq(amountOut, AMOUNT_IN, "venue delivered amount");
+        assertEq(tokenOut.balanceOf(recipient), AMOUNT_IN, "recipient tokenOut");
+        assertEq(IERC20(WETH).balanceOf(address(router)), 0, "no WETH stranded in router");
+    }
+
+    // --- msg.value guards -------------------------------------------------
+
+    function test_ethIn_wrongMsgValueReverts() public {
+        vm.expectRevert(abi.encodeWithSelector(InvalidValue.selector, AMOUNT_IN, AMOUNT_IN - 1));
+        router.swapViaVenueV1{value: AMOUNT_IN - 1}(
+            address(venue), ETH_SENTINEL, address(tokenOut), AMOUNT_IN, AMOUNT_IN, recipient, block.timestamp + 1
+        );
+    }
+}

--- a/test/mocks/MockWETH.sol
+++ b/test/mocks/MockWETH.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.35;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice Minimal WETH9 stand-in for unit tests. Implements the `IWETH`
+/// deposit/withdraw surface on top of a standard ERC20 so it can be `vm.etch`ed
+/// at the canonical mainnet WETH address the router hard-codes in `Constants.sol`.
+/// @dev When etched, the constructor does not run, so `name`/`symbol` storage is
+/// left empty — harmless, the tests never read them. Balances, allowances, and
+/// totalSupply all start at zero and behave normally from there.
+contract MockWETH is ERC20 {
+    constructor() ERC20("Wrapped Ether", "WETH") {}
+
+    function deposit() external payable {
+        _mint(msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 wad) external {
+        _burn(msg.sender, wad);
+        (bool ok,) = msg.sender.call{value: wad}("");
+        require(ok, "WETH: ETH transfer failed");
+    }
+
+    receive() external payable {
+        _mint(msg.sender, msg.value);
+    }
+}


### PR DESCRIPTION
PropAMMs are push-based, meaning we can directly transfer from the sender to the PropAMM, without having the tokens in the router. This saves us an extra transfer as we now do user -> router -> PropAMM.
These changes brought some bugs regarding using ETH as `tokenIn`. Besides fixing it, I added some tests for that cases