### PR TITLE
fix(contract): remove redundant whitelist check

### DIFF
--- a/sdk/python/src/propamm/router/propamm_router_abi.json
+++ b/sdk/python/src/propamm/router/propamm_router_abi.json
@@ -77,6 +77,40 @@
   },
   {
     "type": "function",
+    "name": "_quoteVenueUnchecked",
+    "inputs": [
+      {
+        "name": "venue",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenIn",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenOut",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "addVenue",
     "inputs": [
       {

--- a/sdk/rust/src/router/abi.rs
+++ b/sdk/rust/src/router/abi.rs
@@ -369,6 +369,7 @@ mod tests {
     /// not bind: self-call internals, UUPS/AccessManaged plumbing.
     const OMITTED_FUNCTIONS: &[&str] = &[
         "_dispatchVenue(address,address,address,uint256,uint256,address,uint256,uint256)",
+        "_quoteVenueUnchecked(address,address,address,uint256)",
         "initialize(address,address,address)",
         "proxiableUUID()",
         "upgradeToAndCall(address,bytes)",

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -468,16 +468,38 @@ contract PropAMMRouter is
         returns (uint256 amountOut, address quotedVenue)
     {
         require(_isVenue(venue), UnknownVenue());
+        quotedVenue = venue;
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
 
+    /// @notice Quotes `venue` without the `_isVenue` whitelist gate. Self-only.
+    /// @param venue The venue to quote (trusted to be a whitelisted propAMM or
+    /// the fallback by the self-caller).
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return amountOut The amount of `tokenOut` the venue would produce.
+    function _quoteVenueUnchecked(address venue, address tokenIn, address tokenOut, uint256 amount)
+        external
+        returns (uint256 amountOut)
+    {
+        require(msg.sender == address(this), OnlySelf());
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
+
+    /// @dev Shared quote body for `quoteVenueV1` (whitelist-gated) and
+    /// `_quoteVenueUnchecked` (self-only). Resolves the ETH sentinel to WETH and
+    /// dispatches to the fallback quoter, Bebop, or the common `IPropAMM` interface.
+    function _quoteVenue(address venue, address tokenIn, address tokenOut, uint256 amount)
+        private
+        returns (uint256 amountOut)
+    {
         if (tokenIn == ETH_SENTINEL) {
             tokenIn = WETH;
         }
         if (tokenOut == ETH_SENTINEL) {
             tokenOut = WETH;
         }
-
-        // The asked venue. Kept for retro-compatibility.
-        quotedVenue = venue;
 
         if (venue == fallbackSwapRouter) {
             amountOut =
@@ -529,9 +551,7 @@ contract PropAMMRouter is
         uint256 venueCount = whitelistedVenueCount();
         for (uint256 i = 0; i < venueCount; i++) {
             address candidate = whitelistedVenueAt(i);
-            try this.quoteVenueV1(candidate, tokenIn, tokenOut, amount) returns (
-                uint256 amountOut, address _quotedVenue
-            ) {
+            try this._quoteVenueUnchecked(candidate, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
                 if (amountOut > bestQuote) {
                     bestQuote = amountOut;
                     venue = candidate;
@@ -543,9 +563,7 @@ contract PropAMMRouter is
         // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
         // treats as the Uniswap fallback. Callers may also name that address
         // directly through `swapViaVenueV1` / `quoteVenueV1`.
-        try this.quoteVenueV1(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (
-            uint256 amountOut, address _quotedVenue
-        ) {
+        try this._quoteVenueUnchecked(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
                 venue = fallbackSwapRouter;


### PR DESCRIPTION
**Motivation**
There is a redundant `isVenue` check in the `swapV1` function.

The `swapV1` function selects the best venue via `_pickBestVenue`, which calls `quoteVenueV1` for each whitelisted venue. The problem is that `quoteVenueV1` checks whether the given venue is whitelisted, which is not necessary since the venue is actually retrieved from the whitelist.

**Description**
This PR removes a redundant `isVenue` check on the requoting `swapV1` function, by changing the `_pickBestVenue` function so that it calls the `_quoteVenueUnchecked` (which doesn't check whether the venue is whitelisted) instead of `quoteVenueV1`.

This saves ~3000 gas per venue.