### PR TITLE
perf(contract): remove Uniswap quote in requoting swap functions

### DIFF
--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -540,6 +540,40 @@ contract PropAMMRouter is
         }
     }
 
+    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
+    /// `tokenIn` across the whitelisted propAMMs and the fallback.
+    /// @dev Iterates the live venue whitelist (`_whitelistedVenues`), so venues
+    /// added or removed via `addVenue` / `removeVenue` are reflected without a
+    /// contract upgrade.
+    /// Each venue is queried in its own `try/catch` so a reverting venue —
+    /// including one listed ahead of its interface — is simply skipped. Returns
+    /// `(0, fallbackSwapRouter)` when nothing can be priced — callers that need a
+    /// hard failure (e.g. `quoteV1`) check the zero quote; `swapV1` instead lets
+    /// `_coreSwap` route the `fallbackSwapRouter` to the fallback. The returned
+    /// `venue` is either a whitelisted propAMM or `fallbackSwapRouter`.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return bestQuote The best `tokenOut` amount found across all venues.
+    /// @return venue The venue that produced `bestQuote`.
+    function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
+        internal
+        returns (uint256 bestQuote, address venue)
+    {
+        (bestQuote, venue) = _pickBestPropAMM(tokenIn, tokenOut, amount);
+
+        address fallbackRouter = fallbackSwapRouter;
+        if (venue == address(0)) {
+            venue = fallbackRouter;
+        }
+        try this._quoteVenueUnchecked(fallbackRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
+            if (amountOut > bestQuote) {
+                bestQuote = amountOut;
+                venue = fallbackRouter;
+            }
+        } catch {}
+    }
+
     /// @notice Finds the whitelisted propAMM offering the best `tokenOut` for
     /// `amount` of `tokenIn`.
     /// @dev Iterates the live venue whitelist (`_whitelistedVenues`), so venues
@@ -569,37 +603,6 @@ contract PropAMMRouter is
                 }
             } catch {}
         }
-    }
-
-    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
-    /// `tokenIn` across the whitelisted propAMMs and the Uniswap fallback.
-    /// @dev Delegates to `_pickBestPropAMM` for the propAMMs, then compares the
-    /// Uniswap fallback (defaulting to it when no propAMM could be priced). Returns
-    /// `(0, fallbackSwapRouter)` when nothing can be priced — `quoteV1` checks the
-    /// zero quote for a hard failure. Used only by `quoteV1`, which runs off-chain
-    /// (`eth_call`) where the Uniswap quote is free; the swap entrypoints use
-    /// `_pickBestPropAMM` to skip the expensive on-chain Uniswap quote.
-    /// @param tokenIn The address of the token being sold.
-    /// @param tokenOut The address of the token being bought.
-    /// @param amount The exact amount of `tokenIn` to quote against.
-    /// @return bestQuote The best `tokenOut` amount found across all venues.
-    /// @return venue The venue that produced `bestQuote`.
-    function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
-        internal
-        returns (uint256 bestQuote, address venue)
-    {
-        (bestQuote, venue) = _pickBestPropAMM(tokenIn, tokenOut, amount);
-
-        address fallbackRouter = fallbackSwapRouter;
-        if (venue == address(0)) {
-            venue = fallbackRouter;
-        }
-        try this._quoteVenueUnchecked(fallbackRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
-            if (amountOut > bestQuote) {
-                bestQuote = amountOut;
-                venue = fallbackRouter;
-            }
-        } catch {}
     }
 
     /// @notice Finds the venue offering the best `tokenOut` for `amount` of

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -122,11 +122,10 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Picks the best-quoting whitelisted propAMM via `_pickBestPropAMM`, then
-    /// executes through `_coreSwap`. Routes straight to the Uniswap fallback — without
-    /// paying for an on-chain Uniswap quote — when no propAMM can be priced or the best
-    /// propAMM quote is below `amountOutMin`. Quotes are advisory: `_coreSwap` enforces
-    /// `amountOutMin` against the delivered balance delta and engages the Uniswap
-    /// fallback there if the chosen propAMM under-delivers.
+    /// executes through `_coreSwap`. Routes straight to the Uniswap fallback when 
+    /// no propAMM can be priced or the best propAMM quote is below `amountOutMin`. 
+    /// Quotes are advisory: `_coreSwap` enforces `amountOutMin` against the delivered
+    /// balance delta and engages the Uniswap fallback there if the chosen propAMM under-delivers.
     function swapV1(
         address tokenIn,
         address tokenOut,

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -468,16 +468,38 @@ contract PropAMMRouter is
         returns (uint256 amountOut, address quotedVenue)
     {
         require(_isVenue(venue), UnknownVenue());
+        quotedVenue = venue;
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
 
+    /// @notice Quotes `venue` without the `_isVenue` whitelist gate. Self-only.
+    /// @param venue The venue to quote (trusted to be a whitelisted propAMM or
+    /// the fallback by the self-caller).
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return amountOut The amount of `tokenOut` the venue would produce.
+    function _quoteVenueUnchecked(address venue, address tokenIn, address tokenOut, uint256 amount)
+        external
+        returns (uint256 amountOut)
+    {
+        require(msg.sender == address(this), OnlySelf());
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
+
+    /// @dev Shared quote body for `quoteVenueV1` (whitelist-gated) and
+    /// `_quoteVenueUnchecked` (self-only). Resolves the ETH sentinel to WETH and
+    /// dispatches to the fallback quoter, Bebop, or the common `IPropAMM` interface.
+    function _quoteVenue(address venue, address tokenIn, address tokenOut, uint256 amount)
+        private
+        returns (uint256 amountOut)
+    {
         if (tokenIn == ETH_SENTINEL) {
             tokenIn = WETH;
         }
         if (tokenOut == ETH_SENTINEL) {
             tokenOut = WETH;
         }
-
-        // The asked venue. Kept for retro-compatibility.
-        quotedVenue = venue;
 
         if (venue == fallbackSwapRouter) {
             amountOut =
@@ -529,9 +551,7 @@ contract PropAMMRouter is
         uint256 venueCount = whitelistedVenueCount();
         for (uint256 i = 0; i < venueCount; i++) {
             address candidate = whitelistedVenueAt(i);
-            try this.quoteVenueV1(candidate, tokenIn, tokenOut, amount) returns (
-                uint256 amountOut, address _quotedVenue
-            ) {
+            try this._quoteVenueUnchecked(candidate, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
                 if (amountOut > bestQuote) {
                     bestQuote = amountOut;
                     venue = candidate;
@@ -543,9 +563,7 @@ contract PropAMMRouter is
         // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
         // treats as the Uniswap fallback. Callers may also name that address
         // directly through `swapViaVenueV1` / `quoteVenueV1`.
-        try this.quoteVenueV1(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (
-            uint256 amountOut, address _quotedVenue
-        ) {
+        try this._quoteVenueUnchecked(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
                 venue = fallbackSwapRouter;

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -53,13 +53,13 @@ contract PropAMMRouter is
     /// (`_isVenue`, `quoteVenueV1`, `_dispatchVenue`): a venue de-listed here is
     /// skipped by every selection path and rejected on every explicit path. As an
     /// enumerable set it is also the source of candidates iterated by
-    /// `_pickBestVenue`, so a venue added via `addVenue` is automatically
+    /// `_pickBestPropAMM`, so a venue added via `addVenue` is automatically
     /// considered by `swapV1` / `quoteV1` without a contract upgrade. The Uniswap
     /// V3 fallback (`fallbackSwapRouter`) is the always-available safety net and is
     /// intentionally NOT a member — it is accepted independently of this set.
     /// Seeded with the known propAMMs in `initialize` and managed (access-controlled)
     /// via `addVenue` / `removeVenue`, so its size (and thus the
-    /// `_pickBestVenue` loop bound) is trusted to stay small.
+    /// `_pickBestPropAMM` loop bound) is trusted to stay small.
     /// @dev Declared last to keep the upgradeable storage layout append-only.
     EnumerableSet.AddressSet private _whitelistedVenues;
 
@@ -121,13 +121,12 @@ contract PropAMMRouter is
     //------//
 
     /// @inheritdoc IPropAMMRouter
-    /// @dev Picks the best-quoting venue via `_pickBestVenue`, then executes
-    /// through `_coreSwap`; a `fallbackSwapRouter` selection (the Uniswap
-    /// fallback won, or no venue could quote) routes straight to the fallback venue.
-    /// Reverts `InsufficientOutput`
-    /// before pulling funds when the best quote is under `amountOutMin`. Quotes
-    /// are advisory, so `_coreSwap` re-checks `amountOutMin` against the
-    /// delivered balance delta.
+    /// @dev Picks the best-quoting whitelisted propAMM via `_pickBestPropAMM`, then
+    /// executes through `_coreSwap`. Routes straight to the Uniswap fallback — without
+    /// paying for an on-chain Uniswap quote — when no propAMM can be priced or the best
+    /// propAMM quote is below `amountOutMin`. Quotes are advisory: `_coreSwap` enforces
+    /// `amountOutMin` against the delivered balance delta and engages the Uniswap
+    /// fallback there if the chosen propAMM under-delivers.
     function swapV1(
         address tokenIn,
         address tokenOut,
@@ -136,8 +135,10 @@ contract PropAMMRouter is
         address recipient,
         uint256 deadline
     ) external payable whenNotPaused nonReentrant returns (uint256 amountOut, address executedVenue) {
-        (uint256 bestQuote, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
-        require(bestQuote >= amountOutMin, InsufficientOutput(amountOutMin, bestQuote));
+        (uint256 bestQuote, address venue) = _pickBestPropAMM(tokenIn, tokenOut, amountIn);
+        if (venue == address(0) || bestQuote < amountOutMin) {
+            venue = fallbackSwapRouter;
+        }
 
         (amountOut, executedVenue) = _coreSwap(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline);
         _emitSwapped(executedVenue, tokenIn, tokenOut, amountIn, amountOut, recipient);
@@ -160,9 +161,10 @@ contract PropAMMRouter is
         FrontendFees._validateFee(fee);
 
         uint256 grossMin = FrontendFees._grossUp(amountOutMin, fee.bps);
-        (uint256 bestQuote, address venue) = _pickBestVenue(tokenIn, tokenOut, amountIn);
-
-        require(bestQuote >= grossMin, InsufficientOutput(grossMin, bestQuote));
+        (uint256 bestQuote, address venue) = _pickBestPropAMM(tokenIn, tokenOut, amountIn);
+        if (venue == address(0) || bestQuote < grossMin) {
+            venue = fallbackSwapRouter;
+        }
 
         uint256 delivered;
         (delivered, executedVenue) = _coreSwap(venue, tokenIn, tokenOut, amountIn, grossMin, address(this), deadline);
@@ -538,30 +540,25 @@ contract PropAMMRouter is
         }
     }
 
-    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
-    /// `tokenIn` across the whitelisted propAMMs and the fallback.
+    /// @notice Finds the whitelisted propAMM offering the best `tokenOut` for
+    /// `amount` of `tokenIn`.
     /// @dev Iterates the live venue whitelist (`_whitelistedVenues`), so venues
     /// added or removed via `addVenue` / `removeVenue` are reflected without a
-    /// contract upgrade.
-    /// Each venue is queried in its own `try/catch` so a reverting venue —
-    /// including one listed ahead of its interface — is simply skipped. Returns
-    /// `(0, fallbackSwapRouter)` when nothing can be priced — callers that need a
-    /// hard failure (e.g. `quoteV1`) check the zero quote; `swapV1` instead lets
-    /// `_coreSwap` route the `fallbackSwapRouter` to the fallback. The returned
-    /// `venue` is either a whitelisted propAMM or `fallbackSwapRouter`.
+    /// contract upgrade. Each venue is queried in its own `try/catch` so a reverting
+    /// venue — including one listed ahead of its interface — is simply skipped.
+    /// Does NOT consider the Uniswap fallback: returns `(0, address(0))` when no
+    /// whitelisted propAMM can be priced, so the swap entrypoints route straight to
+    /// the fallback without paying for an on-chain Uniswap quote. `quoteV1` layers
+    /// the fallback on via `_pickBestVenue`.
     /// @param tokenIn The address of the token being sold.
     /// @param tokenOut The address of the token being bought.
     /// @param amount The exact amount of `tokenIn` to quote against.
-    /// @return bestQuote The best `tokenOut` amount found across all venues.
-    /// @return venue The venue that produced `bestQuote`.
-    function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
+    /// @return bestQuote The best `tokenOut` amount across the propAMMs, or 0.
+    /// @return venue The propAMM that produced `bestQuote`, or `address(0)` if none.
+    function _pickBestPropAMM(address tokenIn, address tokenOut, uint256 amount)
         internal
         returns (uint256 bestQuote, address venue)
     {
-        // A venue overtakes it only by quoting strictly more; if none do (or nothing can be priced at all),
-        // `venue` stays `fallbackSwapRouter` and `_coreSwap` routes to fallback.
-        venue = fallbackSwapRouter;
-
         uint256 venueCount = whitelistedVenueCount();
         for (uint256 i = 0; i < venueCount; i++) {
             address candidate = whitelistedVenueAt(i);
@@ -572,15 +569,35 @@ contract PropAMMRouter is
                 }
             } catch {}
         }
+    }
 
-        // Uniswap V3 is the always-present fallback candidate: when it wins,
-        // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
-        // treats as the Uniswap fallback. Callers may also name that address
-        // directly through `swapViaVenueV1` / `quoteVenueV1`.
-        try this._quoteVenueUnchecked(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
+    /// @notice Finds the venue offering the best `tokenOut` for `amount` of
+    /// `tokenIn` across the whitelisted propAMMs and the Uniswap fallback.
+    /// @dev Delegates to `_pickBestPropAMM` for the propAMMs, then compares the
+    /// Uniswap fallback (defaulting to it when no propAMM could be priced). Returns
+    /// `(0, fallbackSwapRouter)` when nothing can be priced — `quoteV1` checks the
+    /// zero quote for a hard failure. Used only by `quoteV1`, which runs off-chain
+    /// (`eth_call`) where the Uniswap quote is free; the swap entrypoints use
+    /// `_pickBestPropAMM` to skip the expensive on-chain Uniswap quote.
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return bestQuote The best `tokenOut` amount found across all venues.
+    /// @return venue The venue that produced `bestQuote`.
+    function _pickBestVenue(address tokenIn, address tokenOut, uint256 amount)
+        internal
+        returns (uint256 bestQuote, address venue)
+    {
+        (bestQuote, venue) = _pickBestPropAMM(tokenIn, tokenOut, amount);
+
+        address fallbackRouter = fallbackSwapRouter;
+        if (venue == address(0)) {
+            venue = fallbackRouter;
+        }
+        try this._quoteVenueUnchecked(fallbackRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
-                venue = fallbackSwapRouter;
+                venue = fallbackRouter;
             }
         } catch {}
     }

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -122,8 +122,8 @@ contract PropAMMRouter is
 
     /// @inheritdoc IPropAMMRouter
     /// @dev Picks the best-quoting whitelisted propAMM via `_pickBestPropAMM`, then
-    /// executes through `_coreSwap`. Routes straight to the Uniswap fallback when 
-    /// no propAMM can be priced or the best propAMM quote is below `amountOutMin`. 
+    /// executes through `_coreSwap`. Routes straight to the Uniswap fallback when
+    /// no propAMM can be priced or the best propAMM quote is below `amountOutMin`.
     /// Quotes are advisory: `_coreSwap` enforces `amountOutMin` against the delivered
     /// balance delta and engages the Uniswap fallback there if the chosen propAMM under-delivers.
     function swapV1(


### PR DESCRIPTION
**Motivation**
The requoting swap functions (`swapV1` and `swapWithFeeV1`) always quote Uniswap (besides all the propAMMs).
The problem is that Uniswap quote costs ~100k gas and it will rarely offer better quote than the propAMMs.

**Description**
This PR updates the requoting swap functions (`swapV1` and `swapWithFeeV1`) so that they don't quote Uniswap anymore.
Now, when the propAMMs are not able to fill the swap, instead of reverting with `InsufficientOutput`, the swap functions route the swap via Uniswap (without quoting).

With this change, we save 100k gas in the most common scenario (when the swap is filled by a propAMM).

In case neither a propAMM nor Uniswap can fill the swap, the cost is almost the same as it was before, since the fallback swap will revert, consuming the gas.