### PR TITLE
fix(sdk): set default gas limit for swap functions in typescript sdk

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -62,7 +62,7 @@ export interface WriteParams extends ReadParams {
    * Explicit gas limit. Overrides both the per-function default
    * ({@link GAS_LIMIT_BY_FUNCTION}) and viem's estimation.
    */
-  gas?: bigint;
+  gasLimit?: bigint;
 }
 
 /**
@@ -231,7 +231,7 @@ export class ContractClient {
 
     return this.walletClient.writeContract({
       ...request,
-      gas: params.gas ?? GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
+      gas: params.gasLimit ?? GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
     });
   }
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -75,8 +75,8 @@ const GAS_LIMIT_BY_FUNCTION: Record<string, bigint> = {
   swapWithFeeV1: 750_000n,
   swapViaSelectedVenuesV1: 700_000n,
   swapViaSelectedVenuesWithFeeV1: 750_000n,
-  swapViaVenueV1: 600_000n,
-  swapViaVenueWithFeeV1: 650_000n,
+  swapViaVenueV1: 500_000n,
+  swapViaVenueWithFeeV1: 550_000n,
 };
 
 export interface CallParams extends WriteParams {
@@ -168,9 +168,9 @@ export class ContractClient {
     const blockOverrides =
       params.blockNumber !== undefined || params.blockTimestamp !== undefined
         ? {
-            ...(params.blockNumber !== undefined && { number: params.blockNumber }),
-            ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
-          }
+          ...(params.blockNumber !== undefined && { number: params.blockNumber }),
+          ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
+        }
         : undefined;
 
     let returnData;

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -168,9 +168,9 @@ export class ContractClient {
     const blockOverrides =
       params.blockNumber !== undefined || params.blockTimestamp !== undefined
         ? {
-          ...(params.blockNumber !== undefined && { number: params.blockNumber }),
-          ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
-        }
+            ...(params.blockNumber !== undefined && { number: params.blockNumber }),
+            ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
+          }
         : undefined;
 
     let returnData;

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -60,6 +60,25 @@ export interface WriteParams extends ReadParams {
   value?: bigint;
 }
 
+/**
+ * Hardcoded gas limit per on-chain function. `write` attaches this value
+ * directly to the transaction, skipping gas estimation entirely — estimation
+ * under-shoots when execution takes a heavier branch than it simulated (e.g. a
+ * cheap venue fill estimated, but the ~2x-costlier Uniswap fallback executed).
+ *
+ * Keyed by on-chain function name; the tiers reflect how much quoting each
+ * entrypoint does (none → all venues). Functions absent here are sent without an
+ * explicit gas limit, so viem estimates them as usual.
+ */
+const GAS_LIMIT_BY_FUNCTION: Record<string, bigint> = {
+  swapV1: 700_000n,
+  swapWithFeeV1: 750_000n,
+  swapViaSelectedVenuesV1: 700_000n,
+  swapViaSelectedVenuesWithFeeV1: 750_000n,
+  swapViaVenueV1: 600_000n,
+  swapViaVenueWithFeeV1: 650_000n,
+};
+
 export interface CallParams extends WriteParams {
   /** State overrides applied to the `eth_call` (third RPC parameter). */
   stateOverride?: StateOverride;
@@ -149,9 +168,9 @@ export class ContractClient {
     const blockOverrides =
       params.blockNumber !== undefined || params.blockTimestamp !== undefined
         ? {
-            ...(params.blockNumber !== undefined && { number: params.blockNumber }),
-            ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
-          }
+          ...(params.blockNumber !== undefined && { number: params.blockNumber }),
+          ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
+        }
         : undefined;
 
     let returnData;
@@ -202,7 +221,10 @@ export class ContractClient {
       value: params.value,
     });
 
-    return this.walletClient.writeContract(request);
+    return this.walletClient.writeContract({
+      ...request,
+      gas: GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
+    });
   }
 
   /** Wait until a transaction is mined and return its receipt. */

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -168,9 +168,9 @@ export class ContractClient {
     const blockOverrides =
       params.blockNumber !== undefined || params.blockTimestamp !== undefined
         ? {
-          ...(params.blockNumber !== undefined && { number: params.blockNumber }),
-          ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
-        }
+            ...(params.blockNumber !== undefined && { number: params.blockNumber }),
+            ...(params.blockTimestamp !== undefined && { time: params.blockTimestamp }),
+          }
         : undefined;
 
     let returnData;
@@ -224,6 +224,29 @@ export class ContractClient {
     return this.walletClient.writeContract({
       ...request,
       gas: GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
+    });
+  }
+
+  /**
+   * Estimate the gas a state-changing call would consume (`eth_estimateGas`),
+   * without sending it. Reverts surface as errors. Note this is the gas the call
+   * is expected to *use* — independent of the (higher) gas limit `write`
+   * attaches via {@link GAS_LIMIT_BY_FUNCTION}.
+   */
+  async estimateGas(params: WriteParams): Promise<bigint> {
+    if (!this.account) {
+      throw new Error(
+        "ContractClient was created without an account; gas estimation is unavailable",
+      );
+    }
+
+    return this.publicClient.estimateContractGas({
+      account: this.account,
+      address: params.address,
+      abi: params.abi,
+      functionName: params.functionName,
+      args: params.args ?? [],
+      value: params.value,
     });
   }
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -75,7 +75,7 @@ export interface WriteParams extends ReadParams {
  * entrypoint does (none → all venues). Functions absent here are sent without an
  * explicit gas limit, so viem estimates them as usual.
  */
-const GAS_LIMIT_BY_FUNCTION: Record<string, bigint> = {
+export const GAS_LIMIT_BY_FUNCTION: Record<string, bigint> = {
   swapV1: 700_000n,
   swapWithFeeV1: 750_000n,
   swapViaSelectedVenuesV1: 700_000n,
@@ -232,29 +232,6 @@ export class ContractClient {
     return this.walletClient.writeContract({
       ...request,
       gas: params.gasLimit ?? GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
-    });
-  }
-
-  /**
-   * Estimate the gas a state-changing call would consume (`eth_estimateGas`),
-   * without sending it. Reverts surface as errors. Note this is the gas the call
-   * is expected to *use* — independent of the (higher) gas limit `write`
-   * attaches via {@link GAS_LIMIT_BY_FUNCTION}.
-   */
-  async estimateGas(params: WriteParams): Promise<bigint> {
-    if (!this.account) {
-      throw new Error(
-        "ContractClient was created without an account; gas estimation is unavailable",
-      );
-    }
-
-    return this.publicClient.estimateContractGas({
-      account: this.account,
-      address: params.address,
-      abi: params.abi,
-      functionName: params.functionName,
-      args: params.args ?? [],
-      value: params.value,
     });
   }
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -58,6 +58,11 @@ export interface ReadParams {
 export interface WriteParams extends ReadParams {
   /** ETH value to send along with the call, in wei. */
   value?: bigint;
+  /**
+   * Explicit gas limit. Overrides both the per-function default
+   * ({@link GAS_LIMIT_BY_FUNCTION}) and viem's estimation.
+   */
+  gas?: bigint;
 }
 
 /**
@@ -206,6 +211,9 @@ export class ContractClient {
   /**
    * Send a state-changing contract call. Simulates first so reverts surface
    * as errors before any gas is spent. Returns the transaction hash.
+   *
+   * Gas limit precedence: an explicit `params.gas`, else the per-function
+   * default ({@link GAS_LIMIT_BY_FUNCTION}), else viem's estimation.
    */
   async write(params: WriteParams): Promise<Hash> {
     if (!this.walletClient || !this.account) {
@@ -223,7 +231,7 @@ export class ContractClient {
 
     return this.walletClient.writeContract({
       ...request,
-      gas: GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
+      gas: params.gas ?? GAS_LIMIT_BY_FUNCTION[params.functionName] ?? request.gas,
     });
   }
 

--- a/sdk/typescript/src/router/index.ts
+++ b/sdk/typescript/src/router/index.ts
@@ -24,7 +24,7 @@ import {
   type OverridesSnapshot,
   type OverridesSource,
 } from "../overrides/index.js";
-import type { ContractClient } from "../client.js";
+import type { ContractClient, WriteParams } from "../client.js";
 
 /** Common parameters shared by every swap entrypoint. */
 export interface SwapParams {
@@ -183,12 +183,37 @@ export class PropAmmRouter {
    * selector, which skims the fee from the output.
    */
   async swap(params: SwapParams, opts: SwapOptions = {}): Promise<Hash> {
+    return this.client.write(this.buildSwapCall(params, opts));
+  }
+
+  /** Same as `swap`, but waits for the receipt and decodes the result. */
+  async swapAndWait(params: SwapParams, opts: SwapOptions = {}): Promise<SwapResult> {
+    return this.waitForSwap(await this.swap(params, opts));
+  }
+
+  /**
+   * Estimate the gas a `swap` with these exact params would consume
+   * (`eth_estimateGas` against current chain state). Use it to show the user the
+   * expected network fee (gas × gas price) before they send. Reverts (e.g. the
+   * swap would fail) surface as errors.
+   *
+   * This is the gas the swap is expected to *use* — what the user actually pays
+   * for. It differs from the (higher) gas limit `swap` attaches to the
+   * transaction to cover branches estimation can under-shoot.
+   */
+  async estimateSwapGas(params: SwapParams, opts: SwapOptions = {}): Promise<bigint> {
+    return this.client.estimateGas(this.buildSwapCall(params, opts));
+  }
+
+  /** Build the `write`/`estimateGas` params for a swap — selector, args, and
+   *  native-ETH value — shared by `swap` and `estimateSwapGas`. */
+  private buildSwapCall(params: SwapParams, opts: SwapOptions): WriteParams {
     const { mode, venueArgs } = venueDispatch(opts.venues);
     const fee = opts.frontendFee;
     if (fee) validateFee(fee);
 
     const selectors = SWAP_SELECTORS[mode];
-    return this.client.write({
+    return {
       address: this.address,
       abi: propAmmRouterAbi,
       // The `WithFee` selectors take the same tuple plus the fee struct last.
@@ -205,12 +230,7 @@ export class PropAmmRouter {
       ],
       // Native-ETH input is signalled by the sentinel and paid via msg.value.
       value: isAddressEqual(params.tokenIn, ETH_SENTINEL) ? params.amountIn : undefined,
-    });
-  }
-
-  /** Same as `swap`, but waits for the receipt and decodes the result. */
-  async swapAndWait(params: SwapParams, opts: SwapOptions = {}): Promise<SwapResult> {
-    return this.waitForSwap(await this.swap(params, opts));
+    };
   }
 
   /**

--- a/sdk/typescript/src/router/index.ts
+++ b/sdk/typescript/src/router/index.ts
@@ -95,6 +95,12 @@ export interface SwapOptions {
    * before sending).
    */
   frontendFee?: FrontendFee;
+  /**
+   * Explicit gas limit for the transaction, in gas units. Overrides the
+   * hardcoded per-function default (`GAS_LIMIT_BY_FUNCTION`). Ignored by
+   * `estimateSwapGas`, which always estimates against chain state.
+   */
+  gas?: bigint;
 }
 
 /** Decoded outcome of a mined swap (from the `Swapped` event). */
@@ -230,6 +236,8 @@ export class PropAmmRouter {
       ],
       // Native-ETH input is signalled by the sentinel and paid via msg.value.
       value: isAddressEqual(params.tokenIn, ETH_SENTINEL) ? params.amountIn : undefined,
+      // Explicit override; falls back to the per-function default in `write`.
+      gas: opts.gas,
     };
   }
 

--- a/sdk/typescript/src/router/index.ts
+++ b/sdk/typescript/src/router/index.ts
@@ -24,7 +24,7 @@ import {
   type OverridesSnapshot,
   type OverridesSource,
 } from "../overrides/index.js";
-import type { ContractClient, WriteParams } from "../client.js";
+import { GAS_LIMIT_BY_FUNCTION, type ContractClient } from "../client.js";
 
 /** Common parameters shared by every swap entrypoint. */
 export interface SwapParams {
@@ -97,8 +97,8 @@ export interface SwapOptions {
   frontendFee?: FrontendFee;
   /**
    * Explicit gas limit for the transaction, in gas units. Overrides the
-   * hardcoded per-function default (`GAS_LIMIT_BY_FUNCTION`). Ignored by
-   * `estimateSwapGas`, which always estimates against chain state.
+   * hardcoded per-function default (`GAS_LIMIT_BY_FUNCTION`); reflected by
+   * `gasLimitFor`.
    */
   gasLimit?: bigint;
 }
@@ -189,37 +189,12 @@ export class PropAmmRouter {
    * selector, which skims the fee from the output.
    */
   async swap(params: SwapParams, opts: SwapOptions = {}): Promise<Hash> {
-    return this.client.write(this.buildSwapCall(params, opts));
-  }
-
-  /** Same as `swap`, but waits for the receipt and decodes the result. */
-  async swapAndWait(params: SwapParams, opts: SwapOptions = {}): Promise<SwapResult> {
-    return this.waitForSwap(await this.swap(params, opts));
-  }
-
-  /**
-   * Estimate the gas a `swap` with these exact params would consume
-   * (`eth_estimateGas` against current chain state). Use it to show the user the
-   * expected network fee (gas × gas price) before they send. Reverts (e.g. the
-   * swap would fail) surface as errors.
-   *
-   * This is the gas the swap is expected to *use* — what the user actually pays
-   * for. It differs from the (higher) gas limit `swap` attaches to the
-   * transaction to cover branches estimation can under-shoot.
-   */
-  async estimateSwapGas(params: SwapParams, opts: SwapOptions = {}): Promise<bigint> {
-    return this.client.estimateGas(this.buildSwapCall(params, opts));
-  }
-
-  /** Build the `write`/`estimateGas` params for a swap — selector, args, and
-   *  native-ETH value — shared by `swap` and `estimateSwapGas`. */
-  private buildSwapCall(params: SwapParams, opts: SwapOptions): WriteParams {
     const { mode, venueArgs } = venueDispatch(opts.venues);
     const fee = opts.frontendFee;
     if (fee) validateFee(fee);
 
     const selectors = SWAP_SELECTORS[mode];
-    return {
+    return this.client.write({
       address: this.address,
       abi: propAmmRouterAbi,
       // The `WithFee` selectors take the same tuple plus the fee struct last.
@@ -238,7 +213,26 @@ export class PropAmmRouter {
       value: isAddressEqual(params.tokenIn, ETH_SENTINEL) ? params.amountIn : undefined,
       // Explicit override; falls back to the per-function default in `write`.
       gasLimit: opts.gasLimit,
-    };
+    });
+  }
+
+  /** Same as `swap`, but waits for the receipt and decodes the result. */
+  async swapAndWait(params: SwapParams, opts: SwapOptions = {}): Promise<SwapResult> {
+    return this.waitForSwap(await this.swap(params, opts));
+  }
+
+  /**
+   * The gas limit `swap`/`swapAndWait` will attach for these options — the
+   * explicit `opts.gasLimit` if set, otherwise the hardcoded per-function
+   * default from {@link GAS_LIMIT_BY_FUNCTION}. Use it to preview the maximum
+   * network fee (gasLimit × gas price) without sending, or to size a balance
+   * check. Pure: no RPC call.
+   */
+  gasLimitFor(opts: SwapOptions = {}): bigint {
+    if (opts.gasLimit !== undefined) return opts.gasLimit;
+    const { mode } = venueDispatch(opts.venues);
+    const selectors = SWAP_SELECTORS[mode];
+    return GAS_LIMIT_BY_FUNCTION[opts.frontendFee ? selectors.withFee : selectors.plain];
   }
 
   /**

--- a/sdk/typescript/src/router/index.ts
+++ b/sdk/typescript/src/router/index.ts
@@ -100,7 +100,7 @@ export interface SwapOptions {
    * hardcoded per-function default (`GAS_LIMIT_BY_FUNCTION`). Ignored by
    * `estimateSwapGas`, which always estimates against chain state.
    */
-  gas?: bigint;
+  gasLimit?: bigint;
 }
 
 /** Decoded outcome of a mined swap (from the `Swapped` event). */
@@ -237,7 +237,7 @@ export class PropAmmRouter {
       // Native-ETH input is signalled by the sentinel and paid via msg.value.
       value: isAddressEqual(params.tokenIn, ETH_SENTINEL) ? params.amountIn : undefined,
       // Explicit override; falls back to the per-function default in `write`.
-      gas: opts.gas,
+      gasLimit: opts.gasLimit,
     };
   }
 


### PR DESCRIPTION
**Motivation**
Before sending a swap transaction, the SDK estimates the gas it will consume, and sets it as the gas limit.
This causes transactions to revert sometimes, due to insufficient gas. This is because the gas estimation may route the swap via a propAMM, but then at execution time the swap might go via a different one or the fallback, changing the gas cost.

**Description**
This PR introduces the following changes:
- Updates the Typescript SDK so that swaps transactions use a predefined gas limit depending on the swap function being called, instead of estimating it every time. A `gas` field is also included in the `SwapOptions` interface so that it can be overridden as well.
- Adds a `gasLimitFor` function that returns the gas limit used for a particular swap call. This is intended to be used in the frontend to give the user a good estimation of the gas fee.