### PR TITLE
fix(sdk): set default gas limit for swap functions in rust sdk

### DIFF
--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -56,8 +56,8 @@ fn gas_limit_for(signature: &str) -> Option<u64> {
         abi::SWAP_WITH_FEE => 750_000,
         abi::SWAP_VIA_SELECTED_VENUES => 700_000,
         abi::SWAP_VIA_SELECTED_VENUES_WITH_FEE => 750_000,
-        abi::SWAP_VIA_VENUE => 600_000,
-        abi::SWAP_VIA_VENUE_WITH_FEE => 650_000,
+        abi::SWAP_VIA_VENUE => 500_000,
+        abi::SWAP_VIA_VENUE_WITH_FEE => 550_000,
         _ => return None,
     })
 }

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -18,6 +18,7 @@ use rex_sdk::client::eth::call_with_overrides;
 use secp256k1::SecretKey;
 
 use crate::error::{Error, Result};
+use crate::router::abi;
 
 /// The receipt type returned by the transport (re-exported from ethrex).
 pub use ethrex_rpc::types::receipt::RpcReceipt as TransactionReceipt;
@@ -35,6 +36,37 @@ pub struct CallOverrides {
     /// Block overrides applied to the call (fourth RPC parameter), e.g. a
     /// pinned `number`/`time`.
     pub block: Option<BlockOverrideSet>,
+}
+
+/// Hardcoded gas limit (gas units) for a given on-chain function signature.
+///
+/// [`ContractClient::send`] attaches this value directly to the transaction,
+/// skipping gas estimation entirely — estimation under-shoots when execution
+/// takes a heavier branch than it simulated (e.g. a cheap venue fill estimated,
+/// but the ~2x-costlier Uniswap fallback executed). Signatures with no entry
+/// return `None` and are estimated by the node as usual.
+///
+/// The tiers reflect how much quoting each entrypoint does (none → all venues).
+/// Values are set above the worst observed gas plus headroom, calibrated against
+/// real mainnet swaps and the `test_gas_*` fork tests. `swap`/`*WithFee` quote
+/// more venues than the measured paths, so they are kept conservatively higher.
+fn gas_limit_for(signature: &str) -> Option<u64> {
+    let limit = if signature == abi::SWAP {
+        700_000
+    } else if signature == abi::SWAP_WITH_FEE {
+        750_000
+    } else if signature == abi::SWAP_VIA_SELECTED_VENUES {
+        700_000
+    } else if signature == abi::SWAP_VIA_SELECTED_VENUES_WITH_FEE {
+        750_000
+    } else if signature == abi::SWAP_VIA_VENUE {
+        600_000
+    } else if signature == abi::SWAP_VIA_VENUE_WITH_FEE {
+        650_000
+    } else {
+        return None;
+    };
+    Some(limit)
 }
 
 /// JSON-RPC contract client. Construct read-only with [`ContractClient::connect`]
@@ -117,9 +149,21 @@ impl ContractClient {
             .map_err(|e| Error::Abi(format!("eth_call returned invalid hex: {e}")))
     }
 
-    /// Sign and send a contract call as an EIP-1559 transaction (gas and
-    /// nonce are filled by the node). Returns the transaction hash.
-    pub async fn send(&self, to: Address, calldata: Vec<u8>, value: Option<U256>) -> Result<H256> {
+    /// Sign and send a contract call as an EIP-1559 transaction (nonce filled
+    /// by the node). Returns the transaction hash.
+    ///
+    /// Gas limit precedence: an explicit `gas`, else the per-function default
+    /// keyed on `signature` ([`gas_limit_for`]), else the node's estimation.
+    /// Passing a limit skips estimation, which can under-shoot the executed
+    /// branch.
+    pub async fn send(
+        &self,
+        to: Address,
+        signature: &str,
+        calldata: Vec<u8>,
+        value: Option<U256>,
+        gas: Option<u64>,
+    ) -> Result<H256> {
         let signer = self.signer.as_ref().ok_or_else(|| {
             Error::InvalidInput(
                 "ContractClient was created without a signer; sends are unavailable".into(),
@@ -129,6 +173,7 @@ impl ContractClient {
         let overrides = Overrides {
             from: Some(signer.address()),
             value,
+            gas_limit: gas.or_else(|| gas_limit_for(signature)),
             ..Default::default()
         };
         let tx = build_generic_tx(

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -51,22 +51,15 @@ pub struct CallOverrides {
 /// real mainnet swaps and the `test_gas_*` fork tests. `swap`/`*WithFee` quote
 /// more venues than the measured paths, so they are kept conservatively higher.
 fn gas_limit_for(signature: &str) -> Option<u64> {
-    let limit = if signature == abi::SWAP {
-        700_000
-    } else if signature == abi::SWAP_WITH_FEE {
-        750_000
-    } else if signature == abi::SWAP_VIA_SELECTED_VENUES {
-        700_000
-    } else if signature == abi::SWAP_VIA_SELECTED_VENUES_WITH_FEE {
-        750_000
-    } else if signature == abi::SWAP_VIA_VENUE {
-        600_000
-    } else if signature == abi::SWAP_VIA_VENUE_WITH_FEE {
-        650_000
-    } else {
-        return None;
-    };
-    Some(limit)
+    Some(match signature {
+        abi::SWAP => 700_000,
+        abi::SWAP_WITH_FEE => 750_000,
+        abi::SWAP_VIA_SELECTED_VENUES => 700_000,
+        abi::SWAP_VIA_SELECTED_VENUES_WITH_FEE => 750_000,
+        abi::SWAP_VIA_VENUE => 600_000,
+        abi::SWAP_VIA_VENUE_WITH_FEE => 650_000,
+        _ => return None,
+    })
 }
 
 /// JSON-RPC contract client. Construct read-only with [`ContractClient::connect`]

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -145,17 +145,17 @@ impl ContractClient {
     /// Sign and send a contract call as an EIP-1559 transaction (nonce filled
     /// by the node). Returns the transaction hash.
     ///
-    /// Gas limit precedence: an explicit `gas`, else the per-function default
-    /// keyed on `signature` ([`gas_limit_for`]), else the node's estimation.
-    /// Passing a limit skips estimation, which can under-shoot the executed
-    /// branch.
+    /// Gas limit precedence: an explicit `gas_limit`, else the per-function
+    /// default keyed on `signature` ([`gas_limit_for`]), else the node's
+    /// estimation. Passing a limit skips estimation, which can under-shoot the
+    /// executed branch.
     pub async fn send(
         &self,
         to: Address,
         signature: &str,
         calldata: Vec<u8>,
         value: Option<U256>,
-        gas: Option<u64>,
+        gas_limit: Option<u64>,
     ) -> Result<H256> {
         let signer = self.signer.as_ref().ok_or_else(|| {
             Error::InvalidInput(
@@ -166,7 +166,7 @@ impl ContractClient {
         let overrides = Overrides {
             from: Some(signer.address()),
             value,
-            gas_limit: gas.or_else(|| gas_limit_for(signature)),
+            gas_limit: gas_limit.or_else(|| gas_limit_for(signature)),
             ..Default::default()
         };
         let tx = build_generic_tx(

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -137,6 +137,9 @@ pub struct SwapOptions {
     /// [1, [`MAX_FEE_BPS`]] and the recipient non-zero (validated before
     /// sending).
     pub frontend_fee: Option<FrontendFee>,
+    /// Explicit gas limit (gas units) for the transaction. Overrides the
+    /// hardcoded per-function default.
+    pub gas: Option<u64>,
 }
 
 /// Typed `PropAMMRouter` bindings. Quotes apply pAMM state overrides from the
@@ -248,7 +251,13 @@ impl PropAmmRouter {
         // Native-ETH input is signalled by the sentinel and paid via msg.value.
         let value = (params.token_in == ETH_SENTINEL).then_some(params.amount_in);
         self.client
-            .send(self.address, encode(signature, &args)?, value)
+            .send(
+                self.address,
+                signature,
+                encode(signature, &args)?,
+                value,
+                opts.gas,
+            )
             .await
     }
 
@@ -344,7 +353,9 @@ impl PropAmmRouter {
             abi::ERC20_APPROVE,
             &[Value::Address(self.address), Value::Uint(amount)],
         )?;
-        self.client.send(token, calldata, None).await
+        self.client
+            .send(token, abi::ERC20_APPROVE, calldata, None, None)
+            .await
     }
 
     /// Current router allowance of `token` granted by `owner`.

--- a/sdk/rust/src/router/mod.rs
+++ b/sdk/rust/src/router/mod.rs
@@ -139,7 +139,7 @@ pub struct SwapOptions {
     pub frontend_fee: Option<FrontendFee>,
     /// Explicit gas limit (gas units) for the transaction. Overrides the
     /// hardcoded per-function default.
-    pub gas: Option<u64>,
+    pub gas_limit: Option<u64>,
 }
 
 /// Typed `PropAMMRouter` bindings. Quotes apply pAMM state overrides from the
@@ -256,7 +256,7 @@ impl PropAmmRouter {
                 signature,
                 encode(signature, &args)?,
                 value,
-                opts.gas,
+                opts.gas_limit,
             )
             .await
     }


### PR DESCRIPTION
**Motivation**
Before sending a swap transaction, the SDK estimates the gas it will consume, and sets it as the gas limit.
This causes transactions to revert sometimes, due to insufficient gas. This is because the gas estimation may route the swap via a propAMM, but then at execution time the swap might go via a different one or the fallback, changing the gas cost.

**Description**
This PR introduces the following changes:
- Updates the Rust SDK so that swaps transactions use a predefined gas limit depending on the swap function being called, instead of estimating it every time. A `gas` parameter is also added in the `ContractClient.send` function so that it can be overridden as well.