### PR TITLE
fix(sdk): set default gas limit for swap functions in python sdk

### DIFF
--- a/sdk/python/src/propamm/client.py
+++ b/sdk/python/src/propamm/client.py
@@ -123,15 +123,15 @@ class ContractClient:
         self,
         function: AsyncContractFunction,
         value: int | None = None,
-        gas: int | None = None,
+        gas_limit: int | None = None,
     ) -> str:
         """Build, sign, and send ``function`` as a transaction. Returns the tx hash.
 
         web3 fills nonce, gas, fees, and chain id via ``build_transaction``.
 
-        Gas limit precedence: an explicit ``gas``, else the per-function default
-        (:data:`GAS_LIMIT_BY_FUNCTION`), else web3's estimation. Setting a limit
-        skips estimation, which can under-shoot the executed branch.
+        Gas limit precedence: an explicit ``gas_limit``, else the per-function
+        default (:data:`GAS_LIMIT_BY_FUNCTION`), else web3's estimation. Setting a
+        limit skips estimation, which can under-shoot the executed branch.
         """
         if self.account is None:
             raise ClientError("ContractClient was created without a signer; sends are unavailable")
@@ -145,9 +145,11 @@ class ContractClient:
                 "nonce": nonce,
             }
             # Setting `gas` makes web3 skip its eth_estimateGas call.
-            gas_limit = gas if gas is not None else GAS_LIMIT_BY_FUNCTION.get(function.fn_name)
-            if gas_limit is not None:
-                tx_params["gas"] = gas_limit
+            limit = (
+                gas_limit if gas_limit is not None else GAS_LIMIT_BY_FUNCTION.get(function.fn_name)
+            )
+            if limit is not None:
+                tx_params["gas"] = limit
             tx = await function.build_transaction(tx_params)
             signed = self.account.sign_transaction(tx)
             raw = getattr(signed, "raw_transaction", None) or signed.rawTransaction

--- a/sdk/python/src/propamm/client.py
+++ b/sdk/python/src/propamm/client.py
@@ -26,6 +26,24 @@ from .error import ClientError, RevertError
 #: How long ``wait_for_transaction`` polls before giving up, in seconds.
 RECEIPT_TIMEOUT_SECONDS = 120
 
+#: Hardcoded gas limit per on-chain function. :meth:`ContractClient.send`
+#: attaches this value directly, skipping gas estimation — estimation
+#: under-shoots when execution takes a heavier branch than it simulated (e.g. a
+#: cheap venue fill estimated, but the ~2x-costlier Uniswap fallback executed).
+#:
+#: Keyed by on-chain function name; the tiers reflect how much quoting each
+#: entrypoint does (none -> all venues). Functions absent here are sent without an
+#: explicit limit, so web3 estimates them as usual. Values are set above the
+#: worst observed gas plus headroom.
+GAS_LIMIT_BY_FUNCTION: dict[str, int] = {
+    "swapV1": 700_000,
+    "swapWithFeeV1": 750_000,
+    "swapViaSelectedVenuesV1": 700_000,
+    "swapViaSelectedVenuesWithFeeV1": 750_000,
+    "swapViaVenueV1": 500_000,
+    "swapViaVenueWithFeeV1": 550_000,
+}
+
 
 class ContractClient:
     """JSON-RPC contract client.
@@ -101,10 +119,19 @@ class ContractClient:
             raise ClientError("eth_call returned no result")
         return bytes(self.w3.to_bytes(hexstr=result))
 
-    async def send(self, function: AsyncContractFunction, value: int | None = None) -> str:
+    async def send(
+        self,
+        function: AsyncContractFunction,
+        value: int | None = None,
+        gas: int | None = None,
+    ) -> str:
         """Build, sign, and send ``function`` as a transaction. Returns the tx hash.
 
         web3 fills nonce, gas, fees, and chain id via ``build_transaction``.
+
+        Gas limit precedence: an explicit ``gas``, else the per-function default
+        (:data:`GAS_LIMIT_BY_FUNCTION`), else web3's estimation. Setting a limit
+        skips estimation, which can under-shoot the executed branch.
         """
         if self.account is None:
             raise ClientError("ContractClient was created without a signer; sends are unavailable")
@@ -112,9 +139,16 @@ class ContractClient:
             # web3 fills gas, fees, and chain id in `build_transaction`, but not the
             # nonce — supply it ourselves (pending, so back-to-back sends don't collide).
             nonce = await self.w3.eth.get_transaction_count(self.account.address, "pending")
-            tx = await function.build_transaction(
-                {"from": self.account.address, "value": value or 0, "nonce": nonce}
-            )
+            tx_params: dict[str, Any] = {
+                "from": self.account.address,
+                "value": value or 0,
+                "nonce": nonce,
+            }
+            # Setting `gas` makes web3 skip its eth_estimateGas call.
+            gas_limit = gas if gas is not None else GAS_LIMIT_BY_FUNCTION.get(function.fn_name)
+            if gas_limit is not None:
+                tx_params["gas"] = gas_limit
+            tx = await function.build_transaction(tx_params)
             signed = self.account.sign_transaction(tx)
             raw = getattr(signed, "raw_transaction", None) or signed.rawTransaction
             return self.w3.to_hex(await self.w3.eth.send_raw_transaction(raw))

--- a/sdk/python/src/propamm/router/bindings.py
+++ b/sdk/python/src/propamm/router/bindings.py
@@ -131,7 +131,7 @@ class SwapOptions:
     frontend_fee: FrontendFee | None = None
     #: Explicit gas limit (gas units) for the transaction. Overrides the
     #: hardcoded per-function default.
-    gas: int | None = None
+    gas_limit: int | None = None
 
 
 # Quote function name per venue-restriction mode.
@@ -227,7 +227,7 @@ class PropAmmRouter:
         function = getattr(self._contract.functions, with_fee if fee else plain)(*args)
         # Native-ETH input is signalled by the sentinel and paid via msg.value.
         value = params.amount_in if _eq(params.token_in, ETH_SENTINEL) else None
-        return await self._send(function, value, opts.gas)
+        return await self._send(function, value, opts.gas_limit)
 
     async def swap_and_wait(
         self, params: SwapParams, opts: SwapOptions | None = None
@@ -313,10 +313,12 @@ class PropAmmRouter:
 
     # ------ Internals ------
 
-    async def _send(self, function: Any, value: int | None = None, gas: int | None = None) -> str:
+    async def _send(
+        self, function: Any, value: int | None = None, gas_limit: int | None = None
+    ) -> str:
         """Send via the client, naming any router custom error in the revert."""
         try:
-            return await self.client.send(function, value, gas)
+            return await self.client.send(function, value, gas_limit)
         except RevertError as error:
             raise _named_revert(error) from error
 

--- a/sdk/python/src/propamm/router/bindings.py
+++ b/sdk/python/src/propamm/router/bindings.py
@@ -129,6 +129,9 @@ class SwapOptions:
     #: Optional frontend fee skimmed from the output; routes through the
     #: contract's ``WithFee`` selector (validated before sending).
     frontend_fee: FrontendFee | None = None
+    #: Explicit gas limit (gas units) for the transaction. Overrides the
+    #: hardcoded per-function default.
+    gas: int | None = None
 
 
 # Quote function name per venue-restriction mode.
@@ -224,7 +227,7 @@ class PropAmmRouter:
         function = getattr(self._contract.functions, with_fee if fee else plain)(*args)
         # Native-ETH input is signalled by the sentinel and paid via msg.value.
         value = params.amount_in if _eq(params.token_in, ETH_SENTINEL) else None
-        return await self._send(function, value)
+        return await self._send(function, value, opts.gas)
 
     async def swap_and_wait(
         self, params: SwapParams, opts: SwapOptions | None = None
@@ -310,10 +313,10 @@ class PropAmmRouter:
 
     # ------ Internals ------
 
-    async def _send(self, function: Any, value: int | None = None) -> str:
+    async def _send(self, function: Any, value: int | None = None, gas: int | None = None) -> str:
         """Send via the client, naming any router custom error in the revert."""
         try:
-            return await self.client.send(function, value)
+            return await self.client.send(function, value, gas)
         except RevertError as error:
             raise _named_revert(error) from error
 


### PR DESCRIPTION
**Motivation**
Before sending a swap transaction, the SDK estimates the gas it will consume, and sets it as the gas limit.
This causes transactions to revert sometimes, due to insufficient gas. This is because the gas estimation may route the swap via a propAMM, but then at execution time the swap might go via a different one or the fallback, changing the gas cost.

**Description**
This PR updates the Python SDK so that swaps transactions use a predefined gas limit depending on the swap function being called, instead of estimating it every time. A `gas` parameter is also added in the `ContractClient.send` function so that it can be overridden as well.