### PR TITLE
docs(sdk): update SDK docs

### DIFF
--- a/sdk/docs/src/pages/python/router/swap.md
+++ b/sdk/docs/src/pages/python/router/swap.md
@@ -118,3 +118,22 @@ tx_hash = await router.swap(
     SwapOptions(frontend_fee=FrontendFee(bps=25, recipient="0x...")),  # 0.25%
 )
 ```
+
+`gas_limit` sets an explicit transaction gas limit, overriding the per-function
+default described below.
+
+```python
+tx_hash = await router.swap(params, SwapOptions(gas_limit=800_000))
+```
+
+## Gas limits
+
+Swaps attach a **hardcoded per-function gas limit** and skip node gas
+estimation. Estimation runs against the current state, but the swap can take a
+heavier branch when it executes, so an estimate can under-shoot and the
+transaction runs out of gas. The hardcoded limits sit above the worst observed
+branch (plus headroom), and are tiered by how much quoting each entrypoint does
+on-chain (a single named venue is cheapest; the all-venues requote is highest).
+
+Pass [`SwapOptions.gas_limit`](/python/types#swapoptions) to override the
+default for a call.

--- a/sdk/docs/src/pages/python/types.md
+++ b/sdk/docs/src/pages/python/types.md
@@ -94,6 +94,7 @@ Per-swap options, accepted by [`swap`](/python/router/swap) and
 class SwapOptions:
     venues: list[str] | None = None
     frontend_fee: FrontendFee | None = None
+    gas_limit: int | None = None
 ```
 
 - `venues` — restrict the swap to these venues: a single entry executes
@@ -102,6 +103,8 @@ class SwapOptions:
   best-quoting venue overall.
 - `frontend_fee` — skim a [frontend fee](#frontendfee) from the output; routes
   the call through the contract's `WithFee` selector.
+- `gas_limit` — explicit transaction gas limit, in gas units. Overrides the
+  hardcoded per-function default (see [swap](/python/router/swap#gas-limits)).
 
 ## FrontendFee
 

--- a/sdk/docs/src/pages/rust/router/swap.md
+++ b/sdk/docs/src/pages/rust/router/swap.md
@@ -89,6 +89,28 @@ let opts = SwapOptions {
 let hash = router.swap_with(&params, &opts).await?;
 ```
 
+`gas_limit` sets an explicit transaction gas limit, overriding the per-function
+default described below.
+
+```rust
+use propamm::router::SwapOptions;
+
+let opts = SwapOptions { gas_limit: Some(800_000), ..Default::default() };
+let hash = router.swap_with(&params, &opts).await?;
+```
+
+## Gas limits
+
+Swaps attach a **hardcoded per-function gas limit** and skip node gas
+estimation. Estimation runs against the current state, but the swap can take a
+heavier branch when it executes, so an estimate can under-shoot and the
+transaction runs out of gas. The hardcoded limits sit above the worst observed
+branch (plus headroom), and are tiered by how much quoting each entrypoint does
+on-chain (a single named venue is cheapest; the all-venues requote is highest).
+
+Pass [`SwapOptions.gas_limit`](/rust/types#swapoptions) to override the default
+for a call.
+
 ## swap_and_wait
 
 Same parameters; additionally waits for the receipt and decodes the outcome.

--- a/sdk/docs/src/pages/rust/types.md
+++ b/sdk/docs/src/pages/rust/types.md
@@ -91,6 +91,7 @@ Per-swap options, accepted by [`swap_with`](/rust/router/swap) and
 pub struct SwapOptions {
     pub venues: Option<Vec<Address>>,
     pub frontend_fee: Option<FrontendFee>,
+    pub gas_limit: Option<u64>,
 }
 ```
 
@@ -100,6 +101,8 @@ pub struct SwapOptions {
   best-quoting venue overall.
 - `frontend_fee` — skim a [frontend fee](#frontendfee) from the output;
   routes the call through the contract's `WithFee` selector.
+- `gas_limit` — explicit transaction gas limit, in gas units. Overrides the
+  hardcoded per-function default (see [swap](/rust/router/swap#gas-limits)).
 
 ## FrontendFee
 

--- a/sdk/docs/src/pages/typescript/router/swap.md
+++ b/sdk/docs/src/pages/typescript/router/swap.md
@@ -112,3 +112,46 @@ const hash = await router.swap(params, {
   frontendFee: { bps: 25, recipient: "0x..." }, // 0.25% to the fee recipient
 });
 ```
+
+`gasLimit` sets an explicit transaction gas limit, overriding the per-function
+default described below.
+
+```ts
+const hash = await router.swap(params, { gasLimit: 800_000n });
+```
+
+## Gas limits
+
+Swaps attach a **hardcoded per-function gas limit** and skip node gas
+estimation. Estimation runs against the current state, but the swap can take a
+heavier branch when it executes, so an estimate can under-shoot and the
+transaction runs out of gas. The hardcoded limits sit above the worst observed
+branch (plus headroom), and are tiered by how much quoting each entrypoint does
+on-chain (a single named venue is cheapest; the all-venues requote is highest).
+
+Pass [`SwapOptions.gasLimit`](/typescript/types#swapoptions) to override the
+default for a call.
+
+## gasLimitFor
+
+Returns the gas limit [`swap`](#swap) / `swapAndWait` will attach for a given
+`SwapOptions` — the explicit `gasLimit` if set, otherwise the hardcoded
+per-function default. Pure (no RPC), so it's suited to previewing the maximum
+network fee (`gasLimit × gas price`) or sizing a balance check before sending.
+
+```ts
+gasLimitFor(opts?: SwapOptions): bigint
+```
+
+```ts
+import { PAMMS } from "propamm/common/pamms";
+
+router.gasLimitFor(); // all-venues swap
+router.gasLimitFor({ venues: [PAMMS.kipseli] }); // single-venue (cheapest)
+router.gasLimitFor({ venues: [PAMMS.fermi, PAMMS.bebop] }); // selected-venues
+router.gasLimitFor({ gasLimit: 800_000n }); // explicit override → 800000n
+
+// fee preview
+const gasPrice = await client.publicClient.getGasPrice();
+const maxFeeWei = router.gasLimitFor({ venues }) * gasPrice;
+```

--- a/sdk/docs/src/pages/typescript/types.md
+++ b/sdk/docs/src/pages/typescript/types.md
@@ -80,6 +80,7 @@ Per-swap options, accepted by [`swap`](/typescript/router/swap) and
 interface SwapOptions {
   venues?: readonly Address[];
   frontendFee?: FrontendFee;
+  gasLimit?: bigint;
 }
 ```
 
@@ -89,6 +90,9 @@ interface SwapOptions {
   best-quoting venue overall.
 - `frontendFee` — skim a [frontend fee](#frontendfee) from the output;
   routes the call through the contract's `WithFee` selector.
+- `gasLimit` — explicit transaction gas limit, in gas units. Overrides the
+  hardcoded per-function default (see [swap](/typescript/router/swap#gas-limits));
+  read the effective value with [`gasLimitFor`](/typescript/router/swap#gaslimitfor).
 
 ## FrontendFee
 


### PR DESCRIPTION
This PR updates the SDK docs including the changes introduced in the PRS #73, #74 and #76.

The docs can be served in the browser with:

```bash
cd sdk/docs
pnpm preview
```