### PR TITLE
chore(sdk): bump SDKs versions and update changelogs

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to the Python SDK (`propamm`) are documented here.
 
 - The `swap` and `swap_and_wait` functions now attach a hardcoded per-function gas limit and
   skip gas estimation, which can under-shoot when execution takes a heavier
-  branch than it simulated. Override per call with the new `SwapOptions.gas_limit`.
+  branch than it simulated. Override the gas limit per call with the new
+  `SwapOptions.gas_limit`.
 
 ## [1.1.2] - 2026-06-25
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the Python SDK (`propamm`) are documented here.
 
 ### Added
 
-- Swaps now attach a hardcoded per-function gas limit and skip gas estimation,
-  which can under-shoot when execution takes a heavier branch than it simulated.
-  Override per call with the new `SwapOptions.gas_limit`.
+- The `swap` and `swap_and_wait` functions now attach a hardcoded per-function gas limit and
+  skip gas estimation, which can under-shoot when execution takes a heavier
+  branch than it simulated. Override per call with the new `SwapOptions.gas_limit`.
 
 ## [1.1.2] - 2026-06-25
 

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Python SDK (`propamm`) are documented here.
 
+## [1.1.3] - 2026-07-01
+
+### Added
+
+- Swaps now attach a hardcoded per-function gas limit and skip gas estimation,
+  which can under-shoot when execution takes a heavier branch than it simulated.
+  Override per call with the new `SwapOptions.gas_limit`.
+
 ## [1.1.2] - 2026-06-25
 
 ### Fixed

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "propamm"
-version = "1.1.2"
+version = "1.1.3"
 description = "Python SDK for interacting with the PropAMM contracts"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "propamm"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to the Rust SDK (`propamm`) are documented here.
 
 ### Added
 
-- Swaps now attach a hardcoded per-function gas limit and skip node gas
-  estimation, which can under-shoot when execution takes a heavier branch than
-  it simulated. Override per call with the new `SwapOptions.gas_limit`.
+- The `swap` and `swap_with` functions (and their `_and_wait` variants) now attach a hardcoded
+  per-function gas limit and skip node gas estimation, which can under-shoot when
+  execution takes a heavier branch than it simulated. Override per call with the
+  new `SwapOptions.gas_limit`.
 
 ## [1.1.1] - 2026-06-25
 

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to the Rust SDK (`propamm`) are documented here.
 
 - The `swap` and `swap_with` functions (and their `_and_wait` variants) now attach a hardcoded
   per-function gas limit and skip node gas estimation, which can under-shoot when
-  execution takes a heavier branch than it simulated. Override per call with the
-  new `SwapOptions.gas_limit`.
+  execution takes a heavier branch than it simulated. Override the gas limit per
+  call with the new `SwapOptions.gas_limit`.
 
 ## [1.1.1] - 2026-06-25
 

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Rust SDK (`propamm`) are documented here.
 
+## [1.1.2] - 2026-07-01
+
+### Added
+
+- Swaps now attach a hardcoded per-function gas limit and skip node gas
+  estimation, which can under-shoot when execution takes a heavier branch than
+  it simulated. Override per call with the new `SwapOptions.gas_limit`.
+
 ## [1.1.1] - 2026-06-25
 
 ### Fixed

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "propamm"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "ethrex-common",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propamm"
-version = "1.1.1"
+version = "1.1.2"
 edition = "2024"
 description = "Rust SDK for the PropAMM Router contract: typed calls, eth_call overrides, and ABI codec over JSON-RPC"
 license = "MIT"

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
+## [1.2.2] - 2026-07-01
+
+### Added
+
+- Swaps now attach a hardcoded per-function gas limit and skip node gas
+  estimation, which can under-shoot when execution takes a heavier branch than
+  it simulated. Override per call with the new `SwapOptions.gasLimit`.
+- `PropAmmRouter.gasLimitFor(opts?)` returns the gas limit a swap will attach
+  for the given options (the explicit `gasLimit`, else the per-function
+  default) — for previewing the maximum network fee without sending.
+
 ## [1.2.1] - 2026-06-25
 
 ### Fixed

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
 - The `swap` and `swapAndWait` functions now attach a hardcoded per-function gas limit and skip
   node gas estimation, which can under-shoot when execution takes a heavier
-  branch than it simulated. Override per call with the new `SwapOptions.gasLimit`.
+  branch than it simulated. Override the gas limit per call with the new
+  `SwapOptions.gasLimit`.
 - `PropAmmRouter.gasLimitFor(opts?)` returns the gas limit a swap will attach
   for the given options (the explicit `gasLimit`, else the per-function
   default) — for previewing the maximum network fee without sending.

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
 ### Added
 
-- Swaps now attach a hardcoded per-function gas limit and skip node gas
-  estimation, which can under-shoot when execution takes a heavier branch than
-  it simulated. Override per call with the new `SwapOptions.gasLimit`.
+- The `swap` and `swapAndWait` functions now attach a hardcoded per-function gas limit and skip
+  node gas estimation, which can under-shoot when execution takes a heavier
+  branch than it simulated. Override per call with the new `SwapOptions.gasLimit`.
 - `PropAmmRouter.gasLimitFor(opts?)` returns the gas limit a swap will attach
   for the given options (the explicit `gasLimit`, else the per-function
   default) — for previewing the maximum network fee without sending.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propamm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packageManager": "pnpm@11.8.0",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",
   "license": "MIT",


### PR DESCRIPTION
This PR bumps the SDKs versions and updates their changelogs.