### PR TITLE
fix(contracts): check quoted amount against `grossMin` in `swapViaSelectedVenuesWithFeeV1`

### DIFF
--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -468,16 +468,38 @@ contract PropAMMRouter is
         returns (uint256 amountOut, address quotedVenue)
     {
         require(_isVenue(venue), UnknownVenue());
+        quotedVenue = venue;
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
 
+    /// @notice Quotes `venue` without the `_isVenue` whitelist gate. Self-only.
+    /// @param venue The venue to quote (trusted to be a whitelisted propAMM or
+    /// the fallback by the self-caller).
+    /// @param tokenIn The address of the token being sold.
+    /// @param tokenOut The address of the token being bought.
+    /// @param amount The exact amount of `tokenIn` to quote against.
+    /// @return amountOut The amount of `tokenOut` the venue would produce.
+    function _quoteVenueUnchecked(address venue, address tokenIn, address tokenOut, uint256 amount)
+        external
+        returns (uint256 amountOut)
+    {
+        require(msg.sender == address(this), OnlySelf());
+        amountOut = _quoteVenue(venue, tokenIn, tokenOut, amount);
+    }
+
+    /// @dev Shared quote body for `quoteVenueV1` (whitelist-gated) and
+    /// `_quoteVenueUnchecked` (self-only). Resolves the ETH sentinel to WETH and
+    /// dispatches to the fallback quoter, Bebop, or the common `IPropAMM` interface.
+    function _quoteVenue(address venue, address tokenIn, address tokenOut, uint256 amount)
+        private
+        returns (uint256 amountOut)
+    {
         if (tokenIn == ETH_SENTINEL) {
             tokenIn = WETH;
         }
         if (tokenOut == ETH_SENTINEL) {
             tokenOut = WETH;
         }
-
-        // The asked venue. Kept for retro-compatibility.
-        quotedVenue = venue;
 
         if (venue == fallbackSwapRouter) {
             amountOut =
@@ -529,9 +551,7 @@ contract PropAMMRouter is
         uint256 venueCount = whitelistedVenueCount();
         for (uint256 i = 0; i < venueCount; i++) {
             address candidate = whitelistedVenueAt(i);
-            try this.quoteVenueV1(candidate, tokenIn, tokenOut, amount) returns (
-                uint256 amountOut, address _quotedVenue
-            ) {
+            try this._quoteVenueUnchecked(candidate, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
                 if (amountOut > bestQuote) {
                     bestQuote = amountOut;
                     venue = candidate;
@@ -543,9 +563,7 @@ contract PropAMMRouter is
         // `venue` is `fallbackSwapRouter`, which `_coreSwap` (via `swapV1`)
         // treats as the Uniswap fallback. Callers may also name that address
         // directly through `swapViaVenueV1` / `quoteVenueV1`.
-        try this.quoteVenueV1(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (
-            uint256 amountOut, address _quotedVenue
-        ) {
+        try this._quoteVenueUnchecked(fallbackSwapRouter, tokenIn, tokenOut, amount) returns (uint256 amountOut) {
             if (amountOut > bestQuote) {
                 bestQuote = amountOut;
                 venue = fallbackSwapRouter;

--- a/src/PropAMMRouter.sol
+++ b/src/PropAMMRouter.sol
@@ -259,7 +259,7 @@ contract PropAMMRouter is
         uint256 grossMin = FrontendFees._grossUp(amountOutMin, fee.bps);
         (uint256 bestQuote, address venue) = _pickBestVenueFrom(venues, tokenIn, tokenOut, amountIn);
 
-        if (venue == address(0) || bestQuote < amountOutMin) {
+        if (venue == address(0) || bestQuote < grossMin) {
             venue = fallbackSwapRouter;
         }
 


### PR DESCRIPTION
**Motivation**
The `swapViaSelectedVenuesWithFeeV1` function checks the quoted amount against `amountOutMin` to decide whether to route via a propAMM or the fallback. But since a fee is taken from the swap output, the swap actually needs to deliver `grossMin`, so the quote should be checked against `grossMin`.

Currently, a quote between `amountOutMin` and `grossMin` passes the check, gets routed via a propAMM, reverts, and then falls back. Checking the quote against `grossMin` routes these swaps directly to the fallback, saving some gas.

**Description**
This PR updates the `swapViaSelectedVenuesWithFeeV1` function so that it checks the quoted amount against `grossMin` instead of `amountOutMin`.

