### PR TITLE
Add the El Zorro propAMM venue to the SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PropAMMRouter
 
-Single-hop router that quotes and executes swaps against a proprietary AMM (FermiSwap, Kipseli, Bebop, Tempest, TaurusFi, or Metric) or directly against Uniswap V3, and falls back to Uniswap V3 when the chosen proprietary venue cannot fill the swap.
+Single-hop router that quotes and executes swaps against a proprietary AMM (FermiSwap, Kipseli, Bebop, Tempest, TaurusFi, Metric, or El Zorro) or directly against Uniswap V3, and falls back to Uniswap V3 when the chosen proprietary venue cannot fill the swap.
 
 ## Deployed Contracts
 
@@ -13,10 +13,11 @@ The PropAMMs the router interacts with are deployed at:
 - Tempest: `0x00000003f1ec2379e79F58E12EC6C4F51Ee92149`
 - TaurusFi: `0x217d58931A8549ca539426AA8152E33dAfc3d95A`
 - Metric: `0xE715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB`
+- El Zorro: `0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3`
 
 ## Overview
 
-Venues are identified **by address**: the proprietary AMM routers (FermiSwap, Kipseli, Bebop, Tempest, TaurusFi, Metric) plus the Uniswap V3 fallback, denoted by the SwapRouter02 address wired in at deployment. The router exposes the following external functions (see `src/interfaces/IPropAMMRouter.sol` for the full NatSpec and the [rationale](https://github.com/lambdaclass/propamm-router-contracts/blob/main/docs/rationale.md) document with some design decisions):
+Venues are identified **by address**: the proprietary AMM routers (FermiSwap, Kipseli, Bebop, Tempest, TaurusFi, Metric, El Zorro) plus the Uniswap V3 fallback, denoted by the SwapRouter02 address wired in at deployment. The router exposes the following external functions (see `src/interfaces/IPropAMMRouter.sol` for the full NatSpec and the [rationale](https://github.com/lambdaclass/propamm-router-contracts/blob/main/docs/rationale.md) document with some design decisions):
 
 - `swapV1(tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: pulls `amountIn` of `tokenIn` from `msg.sender`, routes through the best-quoting venue, and falls back to Uniswap V3 if that venue reverts or under-delivers. Returns `(amountOut, executedVenue)`, where `executedVenue` is the proprietary venue that filled or the SwapRouter02 address when the fallback ran. Routes to Uniswap V3 if the best propAMM quote is below `amountOutMin`, and checks `amountOutMin` against the measured balance delta of `recipient` after execution (`InsufficientOutput`). Reverts when the contract is paused (see [Pausing the contract](#pausing-the-contract)); quote functions remain callable.
 - `swapViaVenueV1(venue, tokenIn, tokenOut, amountIn, amountOutMin, recipient, deadline)`: attempts the caller-specified `venue` first. A proprietary venue still falls back to Uniswap V3 if it fails to fill; naming the Uniswap V3 SwapRouter02 address routes directly to Uniswap V3 (it *is* the fallback, so there is nothing further to fall back to). Reverts `UnknownVenue` if `venue` is neither a whitelisted proprietary AMM nor the SwapRouter02 address.
@@ -179,6 +180,7 @@ This prints `amountOut`, e.g. `2115659878` (≈ 2115.66 USDC for 1 WETH, with US
 | Tempest | `0x00000003f1ec2379e79F58E12EC6C4F51Ee92149` |
 | TaurusFi | `0x217d58931A8549ca539426AA8152E33dAfc3d95A` |
 | Metric | `0xE715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB` |
+| El Zorro | `0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3` |
 
 ### Pausing the contract
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -97,8 +97,10 @@ frontend-fee check, and which builder built the landing block.
 | `selectedwithfee` | `swapViaSelectedVenuesWithFeeV1` | the **candidate set** (best-of), plus a fee skim |
 
 `[venues]` is an optional comma-separated, case-insensitive list — valid names are
-`BEBOP`, `FERMI`, `KIPSELI` (order preserved, dups dropped). Omit it to use all
-three. Uniswap V3 is the safety net in every mode.
+`BEBOP`, `FERMI`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `EL_ZORRO` (order
+preserved, dups dropped). `_` and `-` are ignored when matching, so the SDK's
+`elzorro` key works as-is. Omit the arg to use all seven. Uniswap V3 is the
+safety net in every mode.
 
 ```bash
 # Best-of {KIPSELI, FERMI} with the frontend fee — the router re-quotes BOTH venues

--- a/scripts/execute_direct_swaps.sh
+++ b/scripts/execute_direct_swaps.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # execute_direct_swaps.sh — fire N $1 swaps DIRECTLY at each propAMM venue
-# (KIPSELI -> FERMI -> KIPSELI -> ...), bypassing the PropAMM router entirely.
+# (KIPSELI -> FERMI -> EL_ZORRO -> KIPSELI -> ...), bypassing the PropAMM router
+# entirely.
 #
 # Unlike execute_swaps.sh there is NO Uniswap V3 fallback and NO frontend fee:
 # a venue that cannot fill is skipped (before any funds move) or the tx simply
@@ -14,8 +15,8 @@
 #     to ~0 when every planned Fermi swap executes). Atomic: a failure just
 #     reverts, nothing can get stranded.
 #
-#   KIPSELI (two txs, push-payment — it only implements `IPropAMM`)
-#     tx A: ERC20.transfer(KIPSELI, amountIn)        <- funds pushed first
+#   KIPSELI, EL_ZORRO (two txs, push-payment — they only implement `IPropAMM`)
+#     tx A: ERC20.transfer(venue, amountIn)          <- funds pushed first
 #     tx B: swap(tokenIn, tokenOut, amountIn, minOut, recipient, deadline)
 #     Both are broadcast back-to-back with explicit sequential nonces (no wait
 #     between broadcasts) so they normally land adjacent in the same block,
@@ -30,11 +31,12 @@
 # and moves on. It then quotes the venue directly (`IPropAMM.quote` via
 # eth_call) and sets AMOUNT_OUT_MIN to the quote minus SLIPPAGE_BPS (default
 # 50 bps). A failed quote also skips the swap: with no fallback there is no
-# reason to push funds (Kipseli) or burn gas (Fermi) on a doomed fill.
-# Kipseli's quote is a simulated swap that pulls tokenIn from the CALLER, so
-# it is quoted `--from` the sender, which actually holds the funds (this is
-# the very reason the router can never auto-select Kipseli; direct quoting
-# should fare better, but is only verifiable while Kipseli's lane is fresh).
+# reason to push funds (the push-payment venues) or burn gas (Fermi) on a
+# doomed fill. Kipseli's quote is a simulated swap that pulls tokenIn from the
+# CALLER, so it is quoted `--from` the sender, which actually holds the funds
+# (this is the very reason the router can never auto-select Kipseli; direct
+# quoting should fare better, but is only verifiable while Kipseli's lane is
+# fresh).
 #
 # A one-shot preflight also checks the sender's tokenIn balance: the run
 # aborts if it cannot fund even a single swap, and warns (but proceeds) if it
@@ -50,16 +52,21 @@
 # Usage:
 #   ETH_RPC_URL=<rpc> PK=<priv-key> ./scripts/execute_direct_swaps.sh <num_swaps> [venue]
 #
-# With no <venue>, the script round-robins KIPSELI -> FERMI across the N
-# swaps. Pass a venue name (e.g. FERMI, case-insensitive) to force ALL N
-# swaps at that single venue instead.
+# With no <venue>, the script round-robins KIPSELI -> FERMI -> EL_ZORRO across
+# the N swaps. Pass a venue name to force ALL N swaps at that single venue
+# instead. Names are matched case-insensitively and ignoring `_`/`-`, so the
+# SDK's `elzorro` key and this script's `EL_ZORRO` label both resolve.
 #
 # Examples:
-#   # 4 swaps alternating KIPSELI -> FERMI:
-#   ETH_RPC_URL=https://mainnet.infura.io/v3/<key> PK=0x... ./scripts/execute_direct_swaps.sh 4
+#   # 6 swaps rotating KIPSELI -> FERMI -> EL_ZORRO:
+#   ETH_RPC_URL=https://mainnet.infura.io/v3/<key> PK=0x... ./scripts/execute_direct_swaps.sh 6
 #
 #   # 10 swaps, all directly at FERMI:
 #   ETH_RPC_URL=... PK=... ./scripts/execute_direct_swaps.sh 10 fermi
+#
+#   # 10 swaps, all directly at EL_ZORRO (push-payment: two txs per swap, so
+#   # every one carries the stranding caveat above):
+#   ETH_RPC_URL=... PK=... ./scripts/execute_direct_swaps.sh 10 elzorro
 #
 #   # Give Kipseli's price updater up to 5 minutes to refresh before skipping:
 #   ACTIVE_WAIT_SECS=300 ETH_RPC_URL=... PK=... ./scripts/execute_direct_swaps.sh 2 kipseli
@@ -172,7 +179,7 @@ VENUE_FILTER="${2:-}"                    # optional: force all swaps at one venu
 if ! [[ "$NUM_SWAPS" =~ ^[1-9][0-9]*$ ]]; then
   echo "usage: ETH_RPC_URL=<rpc> PK=<key> $0 <num_swaps> [venue]" >&2
   echo "  <num_swaps> must be a positive integer" >&2
-  echo "  [venue]     optional venue name (KIPSELI or FERMI) to target for every swap" >&2
+  echo "  [venue]     optional venue name (KIPSELI, FERMI or EL_ZORRO) to target for every swap" >&2
   exit 1
 fi
 : "${ETH_RPC_URL:?set ETH_RPC_URL to the JSON-RPC endpoint}"
@@ -190,22 +197,28 @@ USDC=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 WETH=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
 # Venues, indexed in lockstep: VENUE_NAMES[i] lives at VENUE_ADDRS[i].
-# KIPSELI speaks IPropAMM only (push-payment); FERMI is hit through its
-# bespoke single-tx pull interface.
-VENUE_NAMES=(KIPSELI FERMI)
+# KIPSELI and EL_ZORRO speak IPropAMM only (push-payment); FERMI is hit through
+# its bespoke single-tx pull interface. Anything that is not FERMI_NAME takes
+# the generic push path below, so a new IPropAMM venue is just two more lines.
+VENUE_NAMES=(KIPSELI FERMI EL_ZORRO)
 VENUE_ADDRS=(
   0x71e790dd841c8A9061487cb3E78C288E75cE0B3d
   0x5979458912F80B96d30D4220af8E2e4925A33320
+  0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3
 )
 NUM_VENUES=${#VENUE_ADDRS[@]}
 FERMI_NAME=FERMI                         # the pull-payment special case below keys off this
 
-# Build the list of venue indices to actually fire at.
+# Build the list of venue indices to actually fire at. Matching drops case and
+# `_`/`-` so `EL_ZORRO`, `el_zorro` and the SDK's `elzorro` all name the same
+# venue; no two VENUE_NAMES collide once stripped.
+norm_venue() { printf '%s' "$1" | tr -d '[:space:]_-' | tr '[:lower:]' '[:upper:]'; }
+
 ACTIVE_IDXS=()
 if [[ -n "$VENUE_FILTER" ]]; then
-  want=$(printf '%s' "$VENUE_FILTER" | tr '[:lower:]' '[:upper:]')
+  want=$(norm_venue "$VENUE_FILTER")
   for ((v = 0; v < NUM_VENUES; v++)); do
-    if [[ "$want" == "${VENUE_NAMES[$v]}" ]]; then ACTIVE_IDXS=("$v"); break; fi
+    if [[ "$want" == "$(norm_venue "${VENUE_NAMES[$v]}")" ]]; then ACTIVE_IDXS=("$v"); break; fi
   done
   if [[ ${#ACTIVE_IDXS[@]} -eq 0 ]]; then
     echo "error: unknown venue '$VENUE_FILTER'; valid: ${VENUE_NAMES[*]}" >&2
@@ -220,7 +233,7 @@ FILLED_COUNT=()                         # per-venue successful direct fills
 SKIPPED_COUNT=()                        # per-venue skips (inactive / quote failed)
 for ((v = 0; v < NUM_VENUES; v++)); do FILLED_COUNT+=(0); SKIPPED_COUNT+=(0); done
 FAILED_COUNT=0                          # tx reverted / unmined (nothing stranded)
-STRANDED_COUNT=0                        # Kipseli pushes whose swap didn't fill
+STRANDED_COUNT=0                        # push-payment pushes whose swap didn't fill
 STRANDED_TOTAL=0                        # cumulative stranded tokenIn units
 TOTAL_GAS_WEI=0                         # cumulative gasUsed * effectiveGasPrice
 BUILD_TITAN=0
@@ -434,8 +447,8 @@ receipt_gas() {
 }
 
 # --- venue gating & quoting ---------------------------------------------------
-# isActive(tokenIn, tokenOut) — a free view; the one gate that keeps Kipseli's
-# push-payment from ever stranding funds on a stale venue.
+# isActive(tokenIn, tokenOut) — a free view; the one gate that keeps the
+# push-payment venues from ever stranding funds on a stale venue.
 venue_active() {
   local out
   out=$(cast call "$1" "isActive(address,address)(bool)" "$TOKEN_IN" "$TOKEN_OUT" \
@@ -587,7 +600,7 @@ echo
 
 # --- preflight: does the sender hold the run's tokenIn? -----------------------
 # One free eth_call that catches a fat-fingered AMOUNT_IN before any gas burns:
-# an underfunded run would revert every Fermi pull and every Kipseli push
+# an underfunded run would revert every Fermi pull and every IPropAMM push
 # (each one costing real gas). Hard-stop only when even ONE swap can't be
 # funded; a partial balance just warns, since early swaps can still fill.
 TOTAL_IN=$(muldiv "$AMOUNT_IN" "$NUM_SWAPS" 1)
@@ -606,10 +619,10 @@ fi
 echo
 
 # --- approve once for the run's Fermi share ----------------------------------
-# Only Fermi pulls via allowance; Kipseli is push-payment and needs none. The
-# allowance is sized to exactly the planned Fermi swaps, so it self-depletes
-# to ~0 by the end of a fully-successful run (skipped/failed swaps leave a
-# remainder — re-running shrinks or reuses it via the check below).
+# Only Fermi pulls via allowance; the IPropAMM venues are push-payment and need
+# none. The allowance is sized to exactly the planned Fermi swaps, so it self-
+# depletes to ~0 by the end of a fully-successful run (skipped/failed swaps
+# leave a remainder — re-running shrinks or reuses it via the check below).
 if (( FERMI_PLANNED > 0 )); then
   FERMI_ADDR=${VENUE_ADDRS[$FERMI_IDX]}
   allowance=$(cast call "$TOKEN_IN" "allowance(address,address)(uint256)" "$SENDER" "$FERMI_ADDR" \
@@ -659,8 +672,8 @@ for (( i = 0; i < NUM_SWAPS; i++ )); do
   fi
 
   # --- gate 2: direct quote -> slippage floor --------------------------------
-  # No fallback exists out here, so an unquotable venue means skip — never
-  # push funds (Kipseli) or burn gas (Fermi) on a fill nothing priced.
+  # No fallback exists out here, so an unquotable venue means skip — never push
+  # funds (KIPSELI / EL_ZORRO) or burn gas (Fermi) on a fill nothing priced.
   expected_out=$(quote_venue "$venue")
   if [[ -z "$expected_out" || "$expected_out" == "0" ]]; then
     echo "   skip   : $name is active but its direct quote failed — swap skipped, nothing sent"
@@ -710,7 +723,7 @@ for (( i = 0; i < NUM_SWAPS; i++ )); do
     continue
   fi
 
-  # --- KIPSELI: push-payment, two txs, back-to-back nonces --------------------
+  # --- KIPSELI / EL_ZORRO: push-payment, two txs, back-to-back nonces ---------
   # tx A pushes amountIn to the venue; tx B consumes it. Broadcast both before
   # waiting on either so they normally land adjacent in one block. From here
   # on, a mined A without a successful B means STRANDED funds.

--- a/scripts/execute_swaps.sh
+++ b/scripts/execute_swaps.sh
@@ -38,11 +38,12 @@
 # Usage:
 #   ETH_RPC_URL=<rpc> PK=<priv-key> ./scripts/execute_swaps.sh <num_swaps> [venues]
 #
-# <venues> is an optional comma-separated list of venue names (case-insensitive),
-# e.g. "kipseli,fermi". With none, all venues are used. In the single-venue MODEs
-# the list is round-robined one venue per swap (a single name forces all swaps at
-# that venue); in the selected MODEs the list IS the candidate set the router
-# re-quotes and best-fills across.
+# <venues> is an optional comma-separated list of venue names (case-insensitive,
+# `_` and `-` ignored — so the SDK's `elzorro` key and this script's `EL_ZORRO`
+# label both resolve), e.g. "kipseli,fermi". With none, all venues are used. In
+# the single-venue MODEs the list is round-robined one venue per swap (a single
+# name forces all swaps at that venue); in the selected MODEs the list IS the
+# candidate set the router re-quotes and best-fills across.
 #
 # Examples:
 #   # 3 swaps, default mode (withfee, 0.50% fee), venues round-robin from BEBOP:
@@ -183,7 +184,7 @@ VENUE_FILTER="${2:-}"                    # optional: comma-separated venue names
 if ! [[ "$NUM_SWAPS" =~ ^[1-9][0-9]*$ ]]; then
   echo "usage: ETH_RPC_URL=<rpc> PK=<key> $0 <num_swaps> [venues]" >&2
   echo "  <num_swaps> must be a positive integer" >&2
-  echo "  [venues]    optional comma-separated venue names (e.g. kipseli,fermi)" >&2
+  echo "  [venues]    optional comma-separated venue names (e.g. kipseli,fermi,elzorro)" >&2
   exit 1
 fi
 : "${ETH_RPC_URL:?set ETH_RPC_URL to the JSON-RPC endpoint}"
@@ -238,15 +239,19 @@ NUM_VENUES=${#VENUE_ADDRS[@]}
 # preserved, dups removed. With no arg we use every venue. In the single-venue
 # MODEs this list is round-robined one venue per swap; in the selected MODEs it
 # IS the candidate set the router re-quotes and best-fills across.
+# Matching drops case and `_`/`-` so `EL_ZORRO`, `el_zorro` and the SDK's
+# `elzorro` all name the same venue; no two VENUE_NAMES collide once stripped.
+norm_venue() { printf '%s' "$1" | tr -d '[:space:]_-' | tr '[:lower:]' '[:upper:]'; }
+
 ACTIVE_IDXS=()
 if [[ -n "$VENUE_FILTER" ]]; then
   IFS=',' read -r -a _req <<< "$VENUE_FILTER"
   for nm in "${_req[@]}"; do
-    want=$(printf '%s' "$nm" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+    want=$(norm_venue "$nm")
     [[ -z "$want" ]] && continue
     hit=-1
     for ((v = 0; v < NUM_VENUES; v++)); do
-      [[ "$want" == "${VENUE_NAMES[$v]}" ]] && { hit=$v; break; }
+      [[ "$want" == "$(norm_venue "${VENUE_NAMES[$v]}")" ]] && { hit=$v; break; }
     done
     [[ $hit -lt 0 ]] && { echo "error: unknown venue '$nm'; valid: ${VENUE_NAMES[*]}" >&2; exit 1; }
     dup=0

--- a/scripts/execute_swaps.sh
+++ b/scripts/execute_swaps.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # execute_swaps.sh — fire N $1 swaps through the PropAMM router, rotating the
-# venue (BEBOP -> FERMI -> KIPSELI -> TEMPEST -> TAURUSFI -> METRIC -> BEBOP
-# -> ...) across calls.
+# venue (BEBOP -> FERMI -> KIPSELI -> TEMPEST -> TAURUSFI -> METRIC -> EL_ZORRO
+# -> BEBOP -> ...) across calls.
 #
 # Each swap sells 1 USDC ($1) for WETH. The swap function depends on MODE:
 #   MODE=withfee (default) -> `swapViaVenueWithFeeV1`: routes to the named venue
@@ -221,7 +221,7 @@ WETH=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 # These are the propAMMs listed in the README's "Deployed Contracts"; a venue
 # must also be whitelisted on the router (`addVenue`) for it to actually fill —
 # an unlisted one just falls back to Uniswap V3.
-VENUE_NAMES=(BEBOP FERMI KIPSELI TEMPEST TAURUSFI METRIC)
+VENUE_NAMES=(BEBOP FERMI KIPSELI TEMPEST TAURUSFI METRIC EL_ZORRO)
 VENUE_ADDRS=(
   0xB09AaA5614916d7AEb59C295C52c92ca82aDdD76
   0x5979458912F80B96d30D4220af8E2e4925A33320
@@ -229,6 +229,7 @@ VENUE_ADDRS=(
   0x00000003f1ec2379e79F58E12EC6C4F51Ee92149
   0x217d58931A8549ca539426AA8152E33dAfc3d95A
   0xE715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB
+  0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3
 )
 NUM_VENUES=${#VENUE_ADDRS[@]}
 

--- a/scripts/gas/gas_flamegraph.py
+++ b/scripts/gas/gas_flamegraph.py
@@ -25,6 +25,7 @@ NAMES = {
     "0x00000003f1ec2379e79f58e12ec6c4f51ee92149": "Tempest",
     "0x217d58931a8549ca539426aa8152e33dafc3d95a": "TaurusFi",
     "0xe715dc29d2c273d0fc5a03e5cca9ccb0abb1dcdb": "Metric",
+    "0xcf211b4dd0d2be5c173ea57bcf938fc61d1d3bd3": "El Zorro",
     "0x68b3465833fb72a70ecdf485e0e4c7bd8665fc45": "UniswapRouter",
     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48": "USDC",
     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "WETH",

--- a/scripts/gas/router_gas_compare.py
+++ b/scripts/gas/router_gas_compare.py
@@ -73,6 +73,7 @@ VENUE_NAMES = {
     "0x00000003f1ec2379e79f58e12ec6c4f51ee92149": "Tempest",
     "0x217d58931a8549ca539426aa8152e33dafc3d95a": "TaurusFi",
     "0xe715dc29d2c273d0fc5a03e5cca9ccb0abb1dcdb": "Metric",
+    "0xcf211b4dd0d2be5c173ea57bcf938fc61d1d3bd3": "El Zorro",
 }
 
 SYMBOLS = {

--- a/scripts/gas/router_overhead.py
+++ b/scripts/gas/router_overhead.py
@@ -111,6 +111,7 @@ PROPAMMS = {
     "0x00000003f1ec2379e79f58e12ec6c4f51ee92149": "Tempest",
     "0x217d58931a8549ca539426aa8152e33dafc3d95a": "TaurusFi",
     "0xe715dc29d2c273d0fc5a03e5cca9ccb0abb1dcdb": "Metric",
+    "0xcf211b4dd0d2be5c173ea57bcf938fc61d1d3bd3": "El Zorro",
 }
 
 # Whitelisted PropAMMs plus the fallback, for labeling.

--- a/sdk/docs/src/pages/python/helpers.md
+++ b/sdk/docs/src/pages/python/helpers.md
@@ -69,5 +69,5 @@ raises `InvalidInputError` on bad length or hex.
 | Module | Exports |
 |---|---|
 | `common/tokens` | `ETH_SENTINEL` (signals native ETH), `USDC`, `USDT`, `WETH` |
-| `common/pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `PAMMS` (name → address) |
+| `common/pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `EL_ZORRO`, `PAMMS` (name → address) |
 | `common/accounts` | `account_from_key`, `account_from_mnemonic` |

--- a/sdk/docs/src/pages/rust/helpers.md
+++ b/sdk/docs/src/pages/rust/helpers.md
@@ -77,4 +77,4 @@ format_units(1500000.into(), 6);   // "1.5"
 | Module | Exports |
 |---|---|
 | `common::tokens` | `ETH_SENTINEL` (signals native ETH), `USDC`, `USDT`, `WETH` |
-| `common::pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `PAMMS` (name → address array) |
+| `common::pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `EL_ZORRO`, `PAMMS` (name → address array) |

--- a/sdk/docs/src/pages/typescript/helpers.md
+++ b/sdk/docs/src/pages/typescript/helpers.md
@@ -60,6 +60,6 @@ formatUnits(1500000n, 6);  // "1.5"
 | Module | Exports |
 |---|---|
 | `common/tokens` | `ETH_SENTINEL` (signals native ETH), `USDC`, `USDT`, `WETH` |
-| `common/pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `PAMMS` (name → address), `PammName` |
+| `common/pamms` | `FERMI`, `BEBOP`, `KIPSELI`, `TEMPEST`, `TAURUSFI`, `METRIC`, `EL_ZORRO`, `PAMMS` (name → address), `PammName` |
 | `common/chains` | viem's `mainnet`, `anvil`, `sepolia`, `Chain` |
 | `common/accounts` | viem's `privateKeyToAccount`, `mnemonicToAccount`, `Account` |

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Python SDK (`propamm`) are documented here.
 
+## [Unreleased]
+
+### Added
+
+- `EL_ZORRO` venue constant in `common.pamms`, plus its `elzorro` entry in
+  `PAMMS`.
+
 ## [1.2.0] - 2026-08-28
 
 ### Added

--- a/sdk/python/src/propamm/common/pamms.py
+++ b/sdk/python/src/propamm/common/pamms.py
@@ -11,6 +11,7 @@ KIPSELI: ChecksumAddress = to_checksum_address("0x71e790dd841c8A9061487cb3E78C28
 TEMPEST: ChecksumAddress = to_checksum_address("0x00000003f1ec2379e79F58E12EC6C4F51Ee92149")
 TAURUSFI: ChecksumAddress = to_checksum_address("0x217d58931A8549ca539426AA8152E33dAfc3d95A")
 METRIC: ChecksumAddress = to_checksum_address("0xE715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB")
+EL_ZORRO: ChecksumAddress = to_checksum_address("0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3")
 
 #: Curated propAMM name -> venue address mapping, for the ``venues`` option of
 #: quotes and swaps.
@@ -24,4 +25,5 @@ PAMMS: dict[str, ChecksumAddress] = {
     "tempest": TEMPEST,
     "taurusfi": TAURUSFI,
     "metric": METRIC,
+    "elzorro": EL_ZORRO,
 }

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Rust SDK (`propamm`) are documented here.
 
+## [Unreleased]
+
+### Added
+
+- `EL_ZORRO` venue constant in `common::pamms`, plus its `elzorro` entry in
+  `PAMMS` (whose length goes from 6 to 7).
+
 ## [1.2.0] - 2026-08-28
 
 ### Added

--- a/sdk/rust/src/common/pamms.rs
+++ b/sdk/rust/src/common/pamms.rs
@@ -8,19 +8,21 @@ pub const KIPSELI: Address = H160(hex!("71e790dd841c8A9061487cb3E78C288E75cE0B3d
 pub const TEMPEST: Address = H160(hex!("00000003f1ec2379e79F58E12EC6C4F51Ee92149"));
 pub const TAURUSFI: Address = H160(hex!("217d58931A8549ca539426AA8152E33dAfc3d95A"));
 pub const METRIC: Address = H160(hex!("E715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB"));
+pub const EL_ZORRO: Address = H160(hex!("CF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3"));
 
 /// Curated propAMM name → venue address mapping, for the `venues` option of
 /// quotes and swaps.
 ///
 /// The Uniswap V3 fallback is intentionally absent: its address is router
 /// configuration, read it via `PropAmmRouter::fallback_swap_router`.
-pub const PAMMS: [(&str, Address); 6] = [
+pub const PAMMS: [(&str, Address); 7] = [
     ("fermi", FERMI),
     ("bebop", BEBOP),
     ("kipseli", KIPSELI),
     ("tempest", TEMPEST),
     ("taurusfi", TAURUSFI),
     ("metric", METRIC),
+    ("elzorro", EL_ZORRO),
 ];
 
 #[cfg(test)]
@@ -144,7 +146,7 @@ mod tests {
     /// individual constants and carry no duplicates.
     #[test]
     fn pamms_is_consistent() {
-        assert_eq!(PAMMS.len(), 6);
+        assert_eq!(PAMMS.len(), 7);
         for (name, address) in PAMMS {
             assert_ne!(address, Address::zero(), "{name} is the zero address");
             assert_eq!(

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
+## [Unreleased]
+
+### Added
+
+- `EL_ZORRO` venue constant in `common/pamms`, plus its `elzorro` entry in
+  `PAMMS` (and therefore in the `PammName` union).
+
 ## [1.3.0] - 2026-08-28
 
 ### Added

--- a/sdk/typescript/src/common/pamms.ts
+++ b/sdk/typescript/src/common/pamms.ts
@@ -7,6 +7,7 @@ export const KIPSELI: Address = "0x71e790dd841c8A9061487cb3E78C288E75cE0B3d";
 export const TEMPEST: Address = "0x00000003f1ec2379e79F58E12EC6C4F51Ee92149";
 export const TAURUSFI: Address = "0x217d58931A8549ca539426AA8152E33dAfc3d95A";
 export const METRIC: Address = "0xE715Dc29d2c273D0FC5A03e5Cca9CcB0Abb1dCDB";
+export const EL_ZORRO: Address = "0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3";
 
 /**
  * Curated propAMM name → venue address mapping, for the `venues` option of
@@ -22,6 +23,7 @@ export const PAMMS = {
   tempest: TEMPEST,
   taurusfi: TAURUSFI,
   metric: METRIC,
+  elzorro: EL_ZORRO,
 } as const satisfies Record<string, Address>;
 
 export type PammName = keyof typeof PAMMS;

--- a/test/PropAMMRouterForkTests.t.sol
+++ b/test/PropAMMRouterForkTests.t.sol
@@ -27,6 +27,14 @@ contract PropAMMRouterForkTests is Test {
     /// @dev The Kipseli PAMM whitelisted (via `addVenue`) on the live demo router.
     address constant NEW_KIPSELI_PAMM = 0x71e790dd841c8A9061487cb3E78C288E75cE0B3d;
     address constant NEW_FERMI_ROUTER = 0x5979458912F80B96d30D4220af8E2e4925A33320;
+    /// @dev Fermi's live pricing contract: the account that calls `getState`
+    /// while quoting, which is what scopes the registry lane. Fermi rotates
+    /// it when it redeploys; see `_updateFermiPrice` for how to refresh it.
+    address constant FERMI_PRICER = 0x5B56042558012d21Fd3578C8b1d4519196517241;
+    /// @dev The inventory account `NEW_FERMI_ROUTER` pays tokenOut from, via
+    /// `transferFrom`. Found as the `from` of that call inside Fermi's `swap`
+    /// in `forge test -vvvv`.
+    address constant FERMI_VAULT = 0x585d44727129B9C69791B10238Ca605932938B4F;
 
     /// @dev Block of mainnet tx
     /// 0x7c3cb5e32867d724a51cbaede51c165454cbc59324511ff3470b983acaa705f0, a
@@ -86,6 +94,7 @@ contract PropAMMRouterForkTests is Test {
     /// It updates the price before sending the swap transaction.
     function test_swapViaVenueV1Fermi() public {
         _updateFermiPrice();
+        _approveFermiVault();
         _runSwapViaVenueV1(NEW_FERMI_ROUTER);
     }
 
@@ -138,7 +147,7 @@ contract PropAMMRouterForkTests is Test {
         // venue actually reads empty, so `getState` reverts with `0x666a2814`
         // and the whole quote fails. When that happens, refresh this address
         // from the `getState` caller in `forge test -vvvv`.
-        address priceTarget = 0x5B56042558012d21Fd3578C8b1d4519196517241;
+        address priceTarget = FERMI_PRICER;
         uint256 laneIndex = 0x2eec03b8999af9793df60f1395a1b41c29e22b324ea3200ca21bc692979b9d46;
         // Single packed price slot; replayed verbatim, the timestamp is
         // restamped to fork time in `_updateRegistryState`.
@@ -147,6 +156,22 @@ contract PropAMMRouterForkTests is Test {
         uint256[] memory slots = new uint256[](1);
         slots[0] = priceSlot0;
         _updateRegistryState(priceTarget, laneIndex, slots);
+    }
+
+    /// @dev Grants `NEW_FERMI_ROUTER` a max WETH allowance from `FERMI_VAULT`.
+    ///
+    /// Fermi settles a swap by `transferFrom`-ing tokenOut out of the vault to
+    /// the recipient, so its router needs the vault's allowance. On
+    /// mainnet the vault currently has it at zero (Fermi is not publishing
+    /// prices either, so the venue is idle), which makes Fermi's `swap`
+    /// revert; the router then falls back to Uniswap V3, whose output is below
+    /// the replayed Fermi quote, and the swap dies with "Too little received".
+    /// The test wants to exercise the router's propAMM dispatch, not Fermi's
+    /// operational state, so the allowance is restored in the fork the same
+    /// way the price lane is republished above. The vault does hold the WETH.
+    function _approveFermiVault() internal {
+        vm.prank(FERMI_VAULT);
+        IERC20(WETH).approve(NEW_FERMI_ROUTER, type(uint256).max);
     }
 
     function _updateRegistryState(address target, uint256 laneIndex, uint256[] memory slots) internal {


### PR DESCRIPTION
Adds the El Zorro propAMM (`0xCF211B4dD0D2be5C173Ea57Bcf938FC61d1d3bd3`) to the venue mapping of the three SDKs, mirroring #84.

Verified on mainnet against the live router: `isWhitelistedVenue` returns true and `getWhitelistedVenues` lists it as the seventh venue.

- Python / TypeScript / Rust: `EL_ZORRO` constant and `elzorro` entry in `PAMMS`. Rust array length and its consistency test go from 6 to 7.
- Changelogs: entries under `[Unreleased]`, versions not bumped (publish separately as with #87).
- README deployed-contracts list, overview and `VENUE_ADDR` table; SDK docs constant tables.
- `execute_swaps.sh` venue rotation and the gas scripts' label maps.

No contract change: the venue is reached through the `addVenue` whitelist and the generic `IPropAMM` interface.

Checks run locally: `cargo test` (with `REQUIRE_CONTRACT_SRC=1`), `uv run pytest` + ruff, `pnpm check`.
