### PR TITLE
release(sdk): cut 1.3.0 / 1.3.0 / 1.4.0 with the El Zorro venue

### DIFF
--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 All notable changes to the Python SDK (`propamm`) are documented here.
 
-## [Unreleased]
+## [1.3.0] - 2026-09-07
 
 ### Added
 
 - `EL_ZORRO` venue constant in `common.pamms`, plus its `elzorro` entry in
   `PAMMS`.
+
+### Removed
+
+- `TokenOutBalanceDecreased` from the bundled router ABI. The router stopped
+  reverting with it when the bespoke Bebop adapter was removed, so it is no
+  longer part of the compiled ABI and no longer decodes from a revert.
+  ([#67](https://github.com/lambdaclass/propamm-router-contracts/pull/67))
 
 ## [1.2.0] - 2026-08-28
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "propamm"
-version = "1.2.0"
+version = "1.3.0"
 description = "Python SDK for interacting with the PropAMM contracts"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1074,7 +1074,7 @@ wheels = [
 
 [[package]]
 name = "propamm"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/sdk/rust/CHANGELOG.md
+++ b/sdk/rust/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 All notable changes to the Rust SDK (`propamm`) are documented here.
 
-## [Unreleased]
+## [1.3.0] - 2026-09-07
 
 ### Added
 
 - `EL_ZORRO` venue constant in `common::pamms`, plus its `elzorro` entry in
   `PAMMS` (whose length goes from 6 to 7).
+
+### Removed
+
+- `TokenOutBalanceDecreased()` from `ERROR_SIGNATURES`. The router stopped
+  reverting with it when the bespoke Bebop adapter was removed, so the selector
+  no longer decodes into a named error.
+  ([#67](https://github.com/lambdaclass/propamm-router-contracts/pull/67))
 
 ## [1.2.0] - 2026-08-28
 

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "propamm"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "ethrex-common",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propamm"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 description = "Rust SDK for the PropAMM Router contract: typed calls, eth_call overrides, and ABI codec over JSON-RPC"
 license = "MIT"

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 All notable changes to the TypeScript SDK (`propamm`) are documented here.
 
-## [Unreleased]
+## [1.4.0] - 2026-09-07
 
 ### Added
 
 - `EL_ZORRO` venue constant in `common/pamms`, plus its `elzorro` entry in
   `PAMMS` (and therefore in the `PammName` union).
+
+### Removed
+
+- `TokenOutBalanceDecreased()` from `propAmmRouterAbi`. The router stopped
+  reverting with it when the bespoke Bebop adapter was removed, so viem can no
+  longer decode a revert into it.
+  ([#67](https://github.com/lambdaclass/propamm-router-contracts/pull/67))
 
 ## [1.3.0] - 2026-08-28
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propamm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "packageManager": "pnpm@11.8.0",
   "description": "TypeScript SDK for interacting with the PropAMM contracts",
   "license": "MIT",

--- a/sdk/typescript/src/router/abi.ts
+++ b/sdk/typescript/src/router/abi.ts
@@ -3,8 +3,8 @@ import { parseAbi } from "viem";
 /**
  * Public ABI of `PropAMMRouter` (src/PropAMMRouter.sol), kept as
  * human-readable signatures so viem can fully infer argument and return
- * types. The self-call-only internal (`_dispatchVenue`) and UUPS plumbing
- * are intentionally omitted.
+ * types. The self-call-only internals (`_dispatchVenue`,
+ * `_quoteVenueUnchecked`) and UUPS plumbing are intentionally omitted.
  */
 export const propAmmRouterAbi = parseAbi([
   "struct FrontendFee { uint16 bps; address recipient; }",
@@ -65,7 +65,6 @@ export const propAmmRouterAbi = parseAbi([
   "error InsufficientOutput(uint256 expectedAmount, uint256 receivedAmount)",
   "error Expired()",
   "error NoQuotesAvailable()",
-  "error TokenOutBalanceDecreased()",
   "error InvalidFallbackFee(uint24 fee)",
   "error ZeroAddress()",
   "error ArrayLengthMismatch()",


### PR DESCRIPTION
Bumps each SDK from its own base (python 1.2.0 -> 1.3.0, rust 1.2.0 -> 1.3.0, typescript 1.3.0 -> 1.4.0) and dates the `[Unreleased]` changelog sections so the publish tags have something to release.
